### PR TITLE
docs: fix project name/description

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 
-project = "exodus-lambda"
+project = "exodus-gw"
 copyright = "2020, Red Hat"
 author = "Red Hat"
 
@@ -89,12 +89,12 @@ html_theme = "alabaster"
 #
 html_theme_options = {
     "github_user": "release-engineering",
-    "github_repo": "exodus-lambda",
+    "github_repo": "exodus-gw",
     "github_button": False,
     "github_banner": True,
-    "description": "AWS Lambda functions for Red Hat's Content Delivery Network",
+    "description": "Publishing microservice for Red Hat's Content Delivery Network",
     "extra_nav_links": {
-        "Source": "https://github.com/release-engineering/exodus-lambda",
+        "Source": "https://github.com/release-engineering/exodus-gw",
         "Index": "genindex.html",
     },
     # default is 940px which seems to be a little too small to display 88 chars code


### PR DESCRIPTION
Docs config seems to be copied from exodus-lambda with some stale
references left behind.