### PR TITLE
README: fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ exodus-gw
 
 Publishing microservice for Red Hat's Content Delivery Network
 
-[![Build Status](https://travis-ci.org/release-engineering/exodus-gw.svg?branch=master)](https://travis-ci.org/release-engineering/exodus-gw)
+[![Build Status](https://travis-ci.com/release-engineering/exodus-gw.svg?branch=master)](https://travis-ci.com/release-engineering/exodus-gw)
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/exodus-gw/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/exodus-gw?branch=master)
 
 - [Source](https://github.com/release-engineering/exodus-gw)


### PR DESCRIPTION
This project is building on travis-ci.com, not travis-ci.org.
This is fine, but we have to refer to the matching host for the
badge to display correctly.