### PR TITLE
docs: add API reference page using OpenAPI & redoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/openapi/*.json
 
 # PyBuilder
 target/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,6 +94,7 @@ html_theme_options = {
     "github_banner": True,
     "description": "Publishing microservice for Red Hat's Content Delivery Network",
     "extra_nav_links": {
+        "API": "api.html",
         "Source": "https://github.com/release-engineering/exodus-gw",
         "Index": "genindex.html",
     },
@@ -105,6 +106,10 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# This dir contains the generated openapi spec and the static redoc-based
+# api.html for viewing. Copy it alongside the other docs.
+html_extra_path = ["openapi"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/openapi/api.html
+++ b/docs/openapi/api.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>exodus-gw API</title>
+
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <redoc spec-url='openapi.json' hide-hostname='true'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.33/bundles/redoc.standalone.js"> </script>
+</body>
+
+</html>

--- a/exodus_gw/__init__.py
+++ b/exodus_gw/__init__.py
@@ -1,0 +1,5 @@
+# Any modules which add endpoints onto the app must be imported here
+from . import gateway
+
+# Per ASGI conventions, main entry point is accessible as "exodus_gw:application"
+from .app import app as application

--- a/exodus_gw/app.py
+++ b/exodus_gw/app.py
@@ -1,0 +1,3 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="exodus-gw")

--- a/exodus_gw/gateway.py
+++ b/exodus_gw/gateway.py
@@ -1,8 +1,7 @@
-from fastapi import FastAPI
-
-app = FastAPI()
+from .app import app
 
 
 @app.get("/healthcheck")
 def healthcheck():
+    """Returns a successful response if the service is running."""
     return {"200": "OK"}

--- a/scripts/gen-openapi
+++ b/scripts/gen-openapi
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Helper script to generate openapi JSON file
+# during publishing of docs.
+import os
+import json
+
+from exodus_gw import application
+
+api = application.openapi()
+
+with open("docs/openapi/openapi.json", "wt") as f:
+    json.dump(api, f)

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ deps=
 use_develop=true
 commands_pre=
 commands=
+	python scripts/gen-openapi
 	sphinx-build -M html docs docs/_build
 
 [pytest]


### PR DESCRIPTION
Use the OpenAPI spec produced by FastAPI to generate online docs.
All endpoints will be automatically detected and included here.
Right now, this includes only the single /healthcheck endpoint,
so the docs are almost entirely empty.

The API viewer uses redoc, so it's a standalone HTML file not
embedded within the sphinx-generated docs. (I tried also
sphinxcontrib-redoc and sphinxcontrib-openapi, but they don't
seem to support OpenAPI 3.x properly.)

Note that the openapi JSON file needs to be served by a real
web server in order for redoc to work correctly, so viewing
the docs locally needs something like:

    cd docs/_build/html
    python -m http.server 8001
    # then browse to http://localhost:8001

The layout of the application's modules was tweaked slightly to
better support accessing the application object from a script.