### PR TITLE
CODEOWNERS: add missing owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @rohanpm @nathanegillett
+*   @rohanpm @nathanegillett @crungehottman


### PR DESCRIPTION
Ownership of this project was transferred to a new guild.
Ensure all the permanent guild members are marked as owners.