### PR TITLE
Tweak healthcheck response body

### DIFF
--- a/exodus_gw/gateway.py
+++ b/exodus_gw/gateway.py
@@ -4,4 +4,4 @@ from .app import app
 @app.get("/healthcheck")
 def healthcheck():
     """Returns a successful response if the service is running."""
-    return {"200": "OK"}
+    return {"detail": "exodus-gw is running"}

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -2,4 +2,4 @@ from exodus_gw import gateway
 
 
 def test_healthcheck():
-    assert gateway.healthcheck() == {"200": "OK"}
+    assert gateway.healthcheck() == {"detail": "exodus-gw is running"}


### PR DESCRIPTION
We want to give some simple static response here, but {"200": "OK"}
isn't ideal. The response status is meant to be communicated in the
HTTP status code. Embedding in the response body as well encourages
callers to wrongly ignore the HTTP code and opens the possibility
that the two codes might not match.

Let's use the same response model as FastAPI uses by default for
errors, which is:

- no embedded response code
- a "detail" attribute with human-oriented text

This isn't a big deal since this is mainly for internal use, but
let's get it right before adding other APIs.