### PR TITLE
containers: use uvicorn via gunicorn rather than directly

### DIFF
--- a/openshift/containers/exodus-gw/Dockerfile
+++ b/openshift/containers/exodus-gw/Dockerfile
@@ -24,4 +24,7 @@ USER exodus-gw
 EXPOSE 8080
 
 # Run the application
-ENTRYPOINT ["uvicorn", "exodus_gw:application", "--host", "0.0.0.0", "--port", "8080"]
+ENTRYPOINT ["gunicorn", \
+            "-k", "uvicorn.workers.UvicornWorker", \
+            "--bind", "0.0.0.0:8080", \
+            "exodus_gw:application"]

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ starlette
 aioboto3
 defusedxml
 uvicorn
+gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,10 @@ fastapi==0.60.1 \
     --hash=sha256:96f964c3d9da8183f824857ad67c16c00ff3297e7bbca6748f60bd8485ded38c \
     --hash=sha256:9a4faa0e2b9c88a3772f7ce15eb4005bbdd27d1230ab4a0cd3517316175014a6 \
     # via -r requirements.in
+gunicorn==20.0.4 \
+    --hash=sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626 \
+    --hash=sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c \
+    # via -r requirements.in
 h11==0.9.0 \
     --hash=sha256:33d4bca7be0fa039f4e84d50ab00531047e53d6ee8ffbc83501ea602c169cae1 \
     --hash=sha256:4bc6d6a1238b7615b266ada57e0618568066f57dd6fa967d1290ec9309b2f2f1 \


### PR DESCRIPTION
This container is ultimately intended for use in production, so
let's follow the advice from uvicorn docs[1] which is to use
the gunicorn server.

(I'm not aware of any specific problem with running uvicorn
directly; this is mainly a matter of following the suggested
configuration.)

[1] https://www.uvicorn.org/deployment/