### PR TITLE
Refactoring: Addressing various pylint/isort/flake8 errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+import mock
+
+
+@pytest.fixture(autouse=True)
+def mock_s3_client():
+    with mock.patch("aioboto3.client") as mock_client:
+        s3_client = mock.AsyncMock()
+        s3_client.__aenter__.return_value = s3_client
+        mock_client.return_value = s3_client
+        yield s3_client

--- a/tests/s3/test_manage_mpu.py
+++ b/tests/s3/test_manage_mpu.py
@@ -1,22 +1,13 @@
-import mock
-import pytest
 import textwrap
 
+import pytest
+
+import mock
+from exodus_gw.s3.api import abort_multipart_upload, multipart_upload
+from exodus_gw.s3.util import xml_response
 from fastapi import HTTPException
 
-from exodus_gw.s3.api import multipart_upload, abort_multipart_upload, upload
-from exodus_gw.s3.util import xml_response
-
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
-
-
-@pytest.fixture(autouse=True)
-def mock_s3_client():
-    with mock.patch("aioboto3.client") as mock_client:
-        s3_client = mock.AsyncMock()
-        s3_client.__aenter__.return_value = s3_client
-        mock_client.return_value = s3_client
-        yield s3_client
 
 
 @pytest.mark.asyncio
@@ -126,7 +117,7 @@ async def test_complete_mpu(mock_s3_client):
 
 
 @pytest.mark.asyncio
-async def test_bad_mpu_call(mock_s3_client):
+async def test_bad_mpu_call():
     """Mixing uploadId and uploads arguments gives a validation error."""
 
     with pytest.raises(HTTPException) as exc_info:

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps=
 	coveralls
 usedevelop=true
 commands_pre=
+	python -m pip install --require-hashes -r requirements.txt -r test-requirements.txt
 commands=
 	pytest --cov-report=html --cov=exodus_gw {posargs}
 


### PR DESCRIPTION
This PR should be merged before #13.  It will remove some unrelated changes I've pushed there.

`
(exodus) [lmilbaum@lmilbaum exodus-gw]$ pylint tests/s3/test_manage_mpu.py 
************* Module test_manage_mpu
tests/s3/test_manage_mpu.py:6:0: E0401: Unable to import 'exodus_gw.s3.api' (import-error)
tests/s3/test_manage_mpu.py:7:0: E0401: Unable to import 'exodus_gw.s3.util' (import-error)
tests/s3/test_manage_mpu.py:23:26: W0621: Redefining name 'mock_s3_client' from outer scope (line 14) (redefined-outer-name)
tests/s3/test_manage_mpu.py:62:28: W0621: Redefining name 'mock_s3_client' from outer scope (line 14) (redefined-outer-name)
tests/s3/test_manage_mpu.py:129:28: W0621: Redefining name 'mock_s3_client' from outer scope (line 14) (redefined-outer-name)
tests/s3/test_manage_mpu.py:129:28: W0613: Unused argument 'mock_s3_client' (unused-argument)
tests/s3/test_manage_mpu.py:145:25: W0621: Redefining name 'mock_s3_client' from outer scope (line 14) (redefined-outer-name)
tests/s3/test_manage_mpu.py:6:0: W0611: Unused upload imported from exodus_gw.s3.api (unused-import)
tests/s3/test_manage_mpu.py:8:0: C0411: third party import "from fastapi import HTTPException" should be placed before "from exodus_gw.s3.api import abort_multipart_upload, multipart_upload, upload" (wrong-import-order)
`

After applied the changes:
`
exodus) [lmilbaum@lmilbaum exodus-gw]$ pylint tests/s3/test_manage_mpu.py 
************* Module test_manage_mpu
tests/s3/test_manage_mpu.py:6:0: E0401: Unable to import 'exodus_gw.s3.api' (import-error)
tests/s3/test_manage_mpu.py:7:0: E0401: Unable to import 'exodus_gw.s3.util' (import-error)
tests/s3/test_manage_mpu.py:8:0: C0411: third party import "from fastapi import HTTPException" should be placed before "from exodus_gw.s3.api import abort_multipart_upload, multipart_upload" (wrong-import-order)
`

import-error - was not resolved
Redefining name 'mock_s3_client'- was resolved (conftest.py)
Unused argument 'mock_s3_client'- was resolved
Unused upload imported - was resolved
third party import - was not resolved
