### PR TITLE
Fix pylint failure "raise-missing-from"

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -54,7 +54,7 @@ def call_context(
     except Exception:
         summary = "Invalid %s header in request" % header
         LOG.exception(summary)
-        raise HTTPException(400, detail=summary)
+        raise HTTPException(400, detail=summary) from None
 
 
 def caller_roles(context: CallContext = Depends(call_context)) -> Set[str]:


### PR DESCRIPTION
pylint 2.6.0 released on 2020-08-20 added a new raise-missing-from
check, which fails on this code. It appears to suggest using an
explicit "from" whenever a chained exception is raised.

In this case, raising "from None" seems most appropriate, as we
are aiming to give the user a terse HTTP error without details of
any internal exceptions (which have already been logged).