### PR TITLE
Revise dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,0 @@
-version: 1
-update_configs:
-- package_manager: python
-  directory: /
-  update_schedule: live
-  allowed_updates:
-  # Create pull requests automatically for any security fixes
-  - match:
-      update_type: security

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: weekly
+  allow:
+  - dependency-type: all


### PR DESCRIPTION
- migrate from old external dependabot (v1) to
  github-integrated (v2)

- adjust settings to allow all updates. The former config was copied
  from exodus-lambda, but we don't need to be as cautious here since
  the service is not publicly accessible - it should be fine to keep
  all dependencies up-to-date.