### PR TITLE
README: fix impossible step in development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Black](https://black.readthedocs.io/) code style is enforced.
 Enabling autoformatting via a pre-commit hook is recommended:
 
 ```
-pip install -r requirements-dev.txt
+pip install black pre-commit
 pre-commit install
 ```
 


### PR DESCRIPTION
We suggested to install requirements-dev.txt, but this repo doesn't
have that file. I don't really want to create one... let's just
list the two needed deps instead.