### PR TITLE
auth: add an endpoint for basic auth diagnosis

### DIFF
--- a/exodus_gw/gateway.py
+++ b/exodus_gw/gateway.py
@@ -1,8 +1,11 @@
+from fastapi import Depends
+
 from .app import app
 from .publish import create_publish_id
+from .auth import call_context, CallContext
 
 
-@app.get("/healthcheck")
+@app.get("/healthcheck", tags=["service"])
 def healthcheck():
     """Returns a successful response if the service is running."""
     return {"detail": "exodus-gw is running"}
@@ -15,3 +18,40 @@ def publish(env: str):
         return {"error": "environment {0} not found".format(env)}
     create_publish_id()
     return {"detail": "Created Publish Id"}
+
+
+@app.get(
+    "/whoami",
+    response_model=CallContext,
+    tags=["service"],
+    responses={
+        200: {
+            "description": "returns caller's auth context",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "client": {
+                            "roles": ["someRole", "anotherRole"],
+                            "authenticated": True,
+                            "serviceAccountId": "clientappname",
+                        },
+                        "user": {
+                            "roles": ["viewer"],
+                            "authenticated": True,
+                            "internalUsername": "someuser",
+                        },
+                    }
+                }
+            },
+        }
+    },
+)
+def whoami(context: CallContext = Depends(call_context)):
+    """Return basic information on the caller's authentication & authorization context.
+
+    This endpoint may be used to determine whether the caller is authenticated to
+    the exodus-gw service, and if so, which set of role(s) are held by the caller.
+
+    It is a read-only endpoint intended for diagnosing authentication issues.
+    """
+    return context

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -28,3 +28,10 @@ def test_healthcheck():
 )
 def test_publish(env, expected):
     assert gateway.publish(env) == expected
+
+
+def test_whoami():
+    # All work is done by fastapi deserialization, so this doesn't actually
+    # do anything except return the passed object.
+    context = object()
+    assert gateway.whoami(context=context) is context


### PR DESCRIPTION
Let's add a trivial endpoint which can be used to determine whether
the current user is authenticated, along with their roles. Without
this, there is no way to verify directly that the authentication
reverse-proxy is working correctly, or for a user to verify that
they were given the roles they requested, etc.

This also gives the healthcheck and whoami endpoints the same
openapi tag, so that they appear in the API docs together (as both
of them are kind of "meta APIs" relating to the service itself
rather than the exodus CDN.)