### PR TITLE
Make dependabot use Python 3.6 while resolving deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,13 @@ exclude = '''
   | \dist
 )/
 '''
+
+[tool.poetry.dev-dependencies]
+# The point of this setting is to force dependabot to use python 3.6
+# while updating our requirements files. This should match the python
+# version used in Travis CI and in container images.
+#
+# If we omit this, dependabot can use later python versions which can
+# result in stripping needed deps from the requirements files, e.g.
+# it may drop dataclasses which is not available on python >= 3.7.
+python = "~3.6"


### PR DESCRIPTION
Dependabot is currently permitted to use the latest available
Python version. This doesn't work for us - we need pip-compile to
be run using Python 3.6, same as used in our container images,
otherwise the dependencies can be resolved incompatibly.

There is no dependabot-specific config file to control this. It
instead reads the configuration of various other python tools, and
there are several options for setting the version.
Adding it to pyproject.toml in this way seems the best option, as
we can have an explanatory comment and it does not block
development & testing of the project on later python versions.