### PR TITLE
Implement environment support in upload API [RHELDST-2188]

### DIFF
--- a/docs/api-guide.rst
+++ b/docs/api-guide.rst
@@ -60,8 +60,9 @@ Usage:
                         verify='/path/to/bundle.pem',
                         config=Config(client_cert=('client.crt', 'client.key')))
 
+    # Bucket name must match one of the environments defined in exodus-gw.ini
+    bucket = s3.Bucket('dev')
     # Basic APIs such as upload_file now work as usual
-    bucket = s3.Bucket('exodus-cdn-dev')
     bucket.upload_file('/tmp/hello.txt',
                        'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f')
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -76,7 +76,7 @@ Settings
 
 To enable per-environment configuration of exodus-gw, exodus-gw.ini is available to point the
 application at specific AWS resources and declare the AWS profile to use when interacting with
-those resources. Each environment must appear in it's own section with the prefix "env.".
+those resources. Each environment must appear in its own section with the prefix "env.".
 
 .. code-block:: ini
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -67,9 +67,20 @@ Settings
 --------
 
 .. autoclass:: exodus_gw.settings.Settings()
-    :members:
+    :members: call_context_header
 
     exodus-gw may be configured by the following settings.
 
     Each settings value may be overridden using an environment variable of the
     same name, prefixed with ``EXODUS_GW_`` (example: ``EXODUS_GW_CALL_CONTEXT_HEADER``).
+
+To enable per-environment configuration of exodus-gw, exodus-gw.ini is available to point the
+application at specific AWS resources and declare the AWS profile to use when interacting with
+those resources. Each environment must appear in it's own section with the prefix "env.".
+
+.. code-block:: ini
+
+  [env.prod]
+  aws_profile = production
+  bucket = cdn-prod-s3
+  table = cdn-prod-db

--- a/exodus-gw.ini
+++ b/exodus-gw.ini
@@ -1,0 +1,14 @@
+[env.test]
+aws_profile = test
+bucket = my-bucket
+table = my-table
+
+[env.test2]
+aws_profile = test2
+bucket = my-bucket2
+table = my-table2
+
+[env.test3]
+aws_profile = test3
+bucket = my-bucket3
+table = my-table3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import mock
 
 @pytest.fixture(autouse=True)
 def mock_s3_client():
-    with mock.patch("aioboto3.client") as mock_client:
+    with mock.patch("aioboto3.Session") as mock_session:
         s3_client = mock.AsyncMock()
         s3_client.__aenter__.return_value = s3_client
-        mock_client.return_value = s3_client
+        mock_session().client.return_value = s3_client
         yield s3_client

--- a/tests/s3/test_manage_mpu.py
+++ b/tests/s3/test_manage_mpu.py
@@ -22,7 +22,7 @@ async def test_create_mpu(mock_s3_client):
 
     response = await multipart_upload(
         None,
-        bucket="my-bucket",
+        env="test",
         key=TEST_KEY,
         uploads="",
     )
@@ -80,7 +80,7 @@ async def test_complete_mpu(mock_s3_client):
 
     response = await multipart_upload(
         request=request,
-        bucket="my-bucket",
+        env="test",
         key=TEST_KEY,
         uploadId="my-better-upload",
         uploads=None,
@@ -123,7 +123,7 @@ async def test_bad_mpu_call():
     with pytest.raises(HTTPException) as exc_info:
         await multipart_upload(
             request=None,
-            bucket="my-bucket",
+            env="test",
             key=TEST_KEY,
             uploadId="oops",
             uploads="not valid to mix these args",
@@ -137,7 +137,7 @@ async def test_abort_mpu(mock_s3_client):
     """Aborting a multipart upload is correctly delegated to S3."""
 
     response = await abort_multipart_upload(
-        bucket="my-bucket",
+        env="test",
         key=TEST_KEY,
         uploadId="my-lame-upload",
     )

--- a/tests/settings/test_get_settings.py
+++ b/tests/settings/test_get_settings.py
@@ -1,4 +1,7 @@
-from exodus_gw.settings import get_settings
+import pytest
+from fastapi import HTTPException
+
+from exodus_gw.settings import get_settings, get_environment
 
 
 # Note: get_settings is wrapped in lru_cache.
@@ -13,6 +16,11 @@ def test_get_settings_default():
     settings = get_settings()
 
     assert settings.call_context_header == "X-RhApiPlatform-CallContext"
+    assert [env.name for env in settings.environments] == [
+        "test",
+        "test2",
+        "test3",
+    ]
 
 
 def test_get_settings_override(monkeypatch):
@@ -29,3 +37,50 @@ def test_get_settings_override(monkeypatch):
 
     # It should have used the value from environment.
     assert settings.call_context_header == "my-awesome-header"
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        (
+            "test",
+            {
+                "aws_profile": "test",
+                "bucket": "my-bucket",
+                "table": "my-table",
+            },
+        ),
+        (
+            "test2",
+            {
+                "aws_profile": "test2",
+                "bucket": "my-bucket2",
+                "table": "my-table2",
+            },
+        ),
+        (
+            "test3",
+            {
+                "aws_profile": "test3",
+                "bucket": "my-bucket3",
+                "table": "my-table3",
+            },
+        ),
+        ("bad", None),
+    ],
+    ids=["test", "test2", "test3", "bad"],
+)
+def test_get_environment(env, expected):
+    if expected:
+        env_obj = get_environment(env)
+
+        assert env_obj.aws_profile == expected["aws_profile"]
+        assert env_obj.bucket == expected["bucket"]
+        assert env_obj.table == expected["table"]
+
+    else:
+        with pytest.raises(HTTPException) as exc_info:
+            get_environment(env)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Invalid environment='bad'"


### PR DESCRIPTION
This commit removes the 'bucket' parameter from the s3 upload API and
it's endpoints, replacing it with 'env'. The bucket name is now
generated to match the corresponding environment defined in
exodus-gw-config.ini.