### PR TITLE
Revert "Make dependabot use Python 3.6 while resolving deps"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,3 @@ exclude = '''
   | \dist
 )/
 '''
-
-[tool.poetry.dev-dependencies]
-# The point of this setting is to force dependabot to use python 3.6
-# while updating our requirements files. This should match the python
-# version used in Travis CI and in container images.
-#
-# If we omit this, dependabot can use later python versions which can
-# result in stripping needed deps from the requirements files, e.g.
-# it may drop dataclasses which is not available on python >= 3.7.
-python = "~3.6"


### PR DESCRIPTION
This change to pyproject.toml had the intent of causing dependabot
to choose Python 3.6 while running, without other side-effects.
Unfortunately it triggered the following crash from dependabot:

```
  updater | ERROR <job_63067262> Error processing botocore (NoMethodError)
  updater | ERROR <job_63067262> undefined method `downcase' for nil:NilClass
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-python-0.119.4/lib/dependabot/python/name_normaliser.rb:8:in `normalise'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-python-0.119.4/lib/dependabot/python/update_checker.rb:294:in `normalised_name'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-python-0.119.4/lib/dependabot/python/update_checker.rb:280:in `poetry_library?'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-python-0.119.4/lib/dependabot/python/update_checker.rb:104:in `requirements_update_strategy'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:306:in `log_requirements_for_update'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:189:in `check_and_create_pull_request'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:67:in `check_and_create_pr_with_error_handling'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:52:in `block in run'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:52:in `each'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:52:in `run'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/update_files_job.rb:17:in `perform_job'
  updater | ERROR <job_63067262> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:29:in `run'
  updater | ERROR <job_63067262> bin/update_files.rb:21:in `<main>'
```

The reason is that, if the tool.poetry section is present in pyproject.toml
at all, dependabot assumes other metadata is also present - at least the
project "name".

While this could potentially be fixed by adding that metadata, I don't want
to duplicate it from setup.py, nor add additional config for a tool we
aren't using. Additionally, this approach seems to influence the behavior
of dependabot more than initially expected.

Let's revert it, and (elsewhere) introduce another solution instead.

This reverts commit c430043b68849a8b1de78ab9a3e29da132c3d927.