### PR TITLE
Return XML error responses for upload API [RHELDST-3354] 

### DIFF
--- a/exodus_gw/s3/util.py
+++ b/exodus_gw/s3/util.py
@@ -53,13 +53,19 @@ def xml_response(operation: str, **kwargs) -> Response:
     """
     root = Element(operation)
 
+    status_code = kwargs.get("Code", 200)
+
     for (key, value) in kwargs.items():
         child = SubElement(root, key)
         child.text = str(value)
 
     xml = io.BytesIO()
     ElementTree(root).write(xml, encoding="UTF-8", xml_declaration=True)
-    return Response(content=xml.getvalue(), media_type="application/xml")
+    return Response(
+        content=xml.getvalue(),
+        status_code=status_code,
+        media_type="application/xml",
+    )
 
 
 class RequestReader:

--- a/tests/test_exception_handler.py
+++ b/tests/test_exception_handler.py
@@ -1,0 +1,30 @@
+from fastapi import HTTPException
+
+import pytest
+import mock
+
+from exodus_gw.gateway import custom_http_exception_handler
+
+TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint, media_type",
+    [
+        ("/upload/foo/%s" % TEST_KEY, "xml"),
+        ("/foo/publish/%s" % TEST_KEY, "json"),
+        ("/healthcheck", "json"),
+        ("/whoami", "json"),
+    ],
+    ids=["upload", "publish", "healthcheck", "whoami"],
+)
+async def test_custom_http_exception_handler(endpoint, media_type):
+    # Verify that HTTPExceptions raised are handled according to endpoint.
+    # Expand list of endpoints as needed.
+
+    request = mock.Mock(scope={"path": endpoint})
+    err = HTTPException(status_code=600, detail="testing response")
+    response = await custom_http_exception_handler(request, err)
+
+    assert response.media_type == "application/%s" % media_type


### PR DESCRIPTION
To get backtraces from the server when using the upload API, responses
must be in XML format or AWS libraries will fail to parse them.

This commit overrides the HTTPException handler for exodus_gw, allowing
us to generate custom responses. Now HTTPExceptions raised by the upload
API will return XML responses. HTTPExceptions raised by all other
endpoints will fallback to the original HTTPException handler.