### PR TITLE
Avoid confusing UnseekableStreamError on request retries [RHELDST-3407]

### DIFF
--- a/exodus_gw/s3/api.py
+++ b/exodus_gw/s3/api.py
@@ -31,15 +31,14 @@ Differences from the AWS S3 API include:
 from typing import Optional
 import textwrap
 import logging
-import os
 
-import aioboto3
 from fastapi import Request, Response, Path, Query, HTTPException
 
 from ..app import app
 from ..settings import get_environment
 
 from .util import extract_mpu_parts, xml_response, RequestReader
+from .client import S3ClientWrapper as s3_client
 
 
 LOG = logging.getLogger("s3")
@@ -49,19 +48,6 @@ LOG = logging.getLogger("s3")
 # - a way to check if object is already uploaded, e.g. HEAD
 # - limits on chunk sizes during multipart upload should be decided and enforced
 # - requests should be authenticated
-
-
-def s3_client(profile: str):
-    # Certain aspects of the boto client can be tweaked by environment variables
-    # for development.
-
-    # Note: Session creation will fail if provided profile cannot be found.
-    session = aioboto3.Session(profile_name=profile)
-
-    return session.client(
-        "s3",
-        endpoint_url=os.environ.get("EXODUS_GW_S3_ENDPOINT_URL") or None,
-    )
 
 
 @app.post(

--- a/exodus_gw/s3/client.py
+++ b/exodus_gw/s3/client.py
@@ -1,0 +1,80 @@
+import os
+
+import aioboto3
+from botocore.config import Config
+
+
+class S3ClientWrapper:
+    """Helper class to obtain preconfigured S3 clients.
+
+    Clients may be wrapped with additional config and event handlers.
+    """
+
+    def __init__(self, profile: str):
+        """Prepare a client for the given profile. This object must be used
+        via 'async with' in order to obtain access to the client.
+
+        Note: Session creation will fail if provided profile cannot be found.
+        """
+
+        session = aioboto3.Session(profile_name=profile)
+
+        self._client_context = session.client(
+            "s3",
+            endpoint_url=os.environ.get("EXODUS_GW_S3_ENDPOINT_URL") or None,
+            # We don't allow any retries - it's not possible since we're streaming
+            # request bodies directly to S3, we don't buffer it anywhere, so we
+            # can't send it more than once.
+            config=Config(retries={"max_attempts": 1}),
+        )
+
+    async def __aenter__(self):
+        client = await self._client_context.__aenter__()
+
+        client.meta.events.register(
+            "needs-retry.s3.PutObject", self.no_redirects
+        )
+        client.meta.events.register(
+            "needs-retry.s3.CreateMultipartUpload", self.no_redirects
+        )
+
+        return client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._client_context.__aexit__(exc_type, exc, tb)
+
+    @staticmethod
+    def no_redirects(**kwargs):
+        # An event handler for needs-s3.retry.* events which will disable implicit
+        # redirects between regions.
+        #
+        # The S3 client has a built-in feature where, if you do a request to a
+        # bucket in the incorrect region, the client will parse the error response
+        # from the server to detect the correct region and then try again.
+        #
+        # For example, if your config file points at us-east-2 region but your bucket
+        # is at us-east-1, each request will first be issued to us-east-2 which will
+        # fail, then will be issued again to us-east-1.
+        #
+        # We don't want this for two reasons:
+        #
+        # 1. If exodus-gw config has the target region incorrectly configured, we'd like
+        #    to know about that immediately. This implicit redirect behavior (even if it
+        #    worked) would cause most single-request operations to require two requests,
+        #    which is bad for performance, so it would be better to detect and fix the
+        #    incorrect config.
+        #
+        # 2. It's not possible to work anyway, because we are streaming requests from
+        #    the caller directly to S3 without buffering them - meaning that the request
+        #    body is not available anywhere to issue the same request again to a different
+        #    region.
+        #
+        # Thus we disable this redirection feature here. This should be registered onto
+        # relevant needs-retry.s3.* events before using any s3 client.
+        #
+        # Note that there doesn't seem to be any documented API for opting-out of this
+        # boto behavior. The logic here depends on implementation details of the
+        # S3RegionRedirector class in botocore/utils.py.
+        request_dict = kwargs.get("request_dict") or {}
+        context = request_dict.get("context") or {}
+        context["s3_redirected"] = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,5 +8,7 @@ def mock_s3_client():
     with mock.patch("aioboto3.Session") as mock_session:
         s3_client = mock.AsyncMock()
         s3_client.__aenter__.return_value = s3_client
+        # This sub-object uses regular methods, not async
+        s3_client.meta = mock.MagicMock()
         mock_session().client.return_value = s3_client
         yield s3_client

--- a/tests/s3/test_client.py
+++ b/tests/s3/test_client.py
@@ -1,0 +1,48 @@
+import pytest
+
+import aioboto3
+
+from exodus_gw.s3.api import s3_client
+
+
+@pytest.mark.asyncio
+async def test_client_retries_disabled():
+    """Verify that created S3 clients have retries disabled in config."""
+
+    async with s3_client("test-profile-123"):
+        # It should have obtained the client via a session,
+        # passing a config object with retries disabled
+        client_call = aioboto3.Session().client.mock_calls[0]
+        config = client_call.kwargs["config"]
+        assert config.retries == {"max_attempts": 1}
+
+
+@pytest.mark.asyncio
+async def test_client_redirects_disabled():
+    """Verify that created S3 clients have disabled the implicit region redirect feature
+    in boto library."""
+
+    async with s3_client("test-profile-123") as client:
+        # It should have registered handlers for the relevant events
+        register_calls = client.meta.events.register.mock_calls
+
+        # Should have registered for these events
+        event_names = [call.args[0] for call in register_calls]
+        assert event_names == [
+            "needs-retry.s3.PutObject",
+            "needs-retry.s3.CreateMultipartUpload",
+        ]
+
+        # Should have registered the same handler for each one
+        handlers = [call.args[1] for call in register_calls]
+        handlers = list(set(handlers))
+        assert len(handlers) == 1
+
+        # And the handler should have the behavior of disabling
+        # redirects by marking requests as already redirected
+        request_dict = {"some": "fields", "context": {"foo": "bar"}}
+        handlers[0](request_dict=request_dict)
+        assert request_dict == {
+            "some": "fields",
+            "context": {"foo": "bar", "s3_redirected": True},
+        }


### PR DESCRIPTION
This exception was observed from exodus-gw logs when trying to use the
upload API:

  botocore.exceptions.UnseekableStreamError: Need to rewind the stream
  <exodus_gw.s3.util.RequestReader object at 0x7f1869ebe9e8>, but stream is not seekable.

The reason for this is the combination of the following:

- For best performance and lowest overhead, as we receive requests,
  we stream the request body to S3 without saving it in memory.

- This means there is no way to read the request body more than once,
  as we haven't stored it anywhere.

- The boto library has a couple of features which cause it to attempt
  reading the request body more than once. One is retrying failed
  requests, which is documented, configurable & enabled by default.
  Another is automatically redirecting you to the correct region if
  you set up the s3 client pointing at the wrong region.

Altogether this means that, if a request to S3 failed for some reason
or was pointed at the incorrect region, the original error may be
swallowed and replaced by this UnseekableStreamError as boto attempts
a second request.

To fix that, let's disable the functionality in the boto library
which can cause it to retry requests.

This is a good idea anyway, as the exodus-gw client will already
have retry logic by default and this should not be doubled up in
both places; and because the implicit region redirect is an
antifeature for us, as we'd rather detect a wrong region in config
immediately.