### PR TITLE
linting with flake8 via GitHub Actions workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,23 @@
+name: Python application
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test-requirements.txt
+      - name: Lint with flake8
+        run: |
+          flake8 --max-line-length=100 .

--- a/exodus_gw/__init__.py
+++ b/exodus_gw/__init__.py
@@ -1,5 +1,6 @@
 # Any modules which add endpoints onto the app must be imported here
-from . import gateway, s3
+from . import gateway, s3  # noqa
 
-# Per ASGI conventions, main entry point is accessible as "exodus_gw:application"
-from .app import app as application
+# Per ASGI conventions, main entry point is accessible as
+# "exodus_gw:application"
+from .app import app as application  # noqa

--- a/exodus_gw/s3/__init__.py
+++ b/exodus_gw/s3/__init__.py
@@ -1,1 +1,1 @@
-from . import api
+from . import api  # noqa

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -19,3 +19,4 @@ six
 sphinx
 wcwidth
 zipp
+flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -92,6 +92,10 @@ docutils==0.15.2 \
     --hash=sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827 \
     --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99 \
     # via sphinx
+flake8==3.8.4 \
+    --hash=sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839 \
+    --hash=sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b \
+    # via -r test-requirements.in
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
@@ -103,7 +107,7 @@ imagesize==1.2.0 \
 importlib-metadata==2.0.0 \
     --hash=sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da \
     --hash=sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3 \
-    # via -r test-requirements.in, pluggy, pytest
+    # via -r test-requirements.in, flake8, pluggy, pytest
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32 \
@@ -177,7 +181,7 @@ markupsafe==1.1.1 \
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
-    # via pylint
+    # via flake8, pylint
 mock==4.0.2 \
     --hash=sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0 \
     --hash=sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72 \
@@ -206,6 +210,14 @@ py==1.9.0 \
     --hash=sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2 \
     --hash=sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342 \
     # via -r test-requirements.in, pytest
+pycodestyle==2.6.0 \
+    --hash=sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367 \
+    --hash=sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e \
+    # via flake8
+pyflakes==2.2.0 \
+    --hash=sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92 \
+    --hash=sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8 \
+    # via flake8
 pygments==2.7.2 \
     --hash=sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0 \
     --hash=sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773 \
@@ -354,3 +366,7 @@ zipp==3.4.0 \
     --hash=sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108 \
     --hash=sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb \
     # via -r test-requirements.in, importlib-metadata
+
+# WARNING: The following packages were not pinned, but pip requires them to be
+# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
+# setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,12 @@ def mock_s3_client():
         s3_client.meta = mock.MagicMock()
         mock_session().client.return_value = s3_client
         yield s3_client
+
+
+@pytest.fixture()
+def mock_request_reader():
+    # We don't use the real request reader for these tests as it becomes
+    # rather complicated to verify that boto methods were called with the
+    # correct expected value. The class is tested separately.
+    with mock.patch("exodus_gw.s3.util.RequestReader.get_reader") as m:
+        yield m

--- a/tests/s3/test_upload.py
+++ b/tests/s3/test_upload.py
@@ -1,22 +1,11 @@
 import mock
 import pytest
-import textwrap
 
 from fastapi import HTTPException
 
-from exodus_gw.s3.api import multipart_upload, abort_multipart_upload, upload
-from exodus_gw.s3.util import xml_response
+from exodus_gw.s3.api import upload
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
-
-
-@pytest.fixture()
-def mock_request_reader():
-    # We don't use the real request reader for these tests as it becomes
-    # rather complicated to verify that boto methods were called with the
-    # correct expected value. The class is tested separately.
-    with mock.patch("exodus_gw.s3.util.RequestReader.get_reader") as m:
-        yield m
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
flake8 is checking the code base against coding style (PEP8). 
The PR includes a GitHub Actions workflow which runs flake8. It also includes the fixes for the errors flake8 raised in the current code base. 
I have used GitHub Actions in this PR, so that we can see how it works for us as apposed to tox+Travis.  