### PR TITLE
Implement initial DynamoDB API [RHELDST-2161]

### DIFF
--- a/exodus_gw/aws/client.py
+++ b/exodus_gw/aws/client.py
@@ -78,3 +78,31 @@ class S3ClientWrapper:
         request_dict = kwargs.get("request_dict") or {}
         context = request_dict.get("context") or {}
         context["s3_redirected"] = True
+
+
+class DynamoDBClientWrapper:
+    """Helper class to obtain preconfigured DynamoDB clients.
+
+    Clients may be wrapped with additional config and event handlers.
+    """
+
+    def __init__(self, profile: str):
+        """Prepare a client for the given profile. This object must be used
+        via 'async with' in order to obtain access to the client.
+
+        Note: Session creation will fail if provided profile cannot be found.
+        """
+
+        session = aioboto3.Session(profile_name=profile)
+
+        self._client_context = session.client(
+            "dynamodb",
+            endpoint_url=os.environ.get("EXODUS_GW_DYNAMODB_ENDPOINT_URL")
+            or None,
+        )
+
+    async def __aenter__(self):
+        return await self._client_context.__aenter__()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._client_context.__aexit__(exc_type, exc, tb)

--- a/exodus_gw/routers/dynamodb.py
+++ b/exodus_gw/routers/dynamodb.py
@@ -1,0 +1,42 @@
+import logging
+from typing import List
+
+import backoff
+
+from ..aws.client import DynamoDBClientWrapper as ddb_client
+from ..settings import get_environment, get_settings
+
+LOG = logging.getLogger("exodus-gw")
+
+
+@backoff.on_predicate(
+    backoff.expo,
+    lambda response: response["UnprocessedItems"],
+    max_time=get_settings().write_max_time,
+)
+async def batch_write(env: str, items: List[dict], delete: bool = False):
+    """Write (or delete) 25 items on the given environment's table."""
+
+    if len(items) > 25:
+        LOG.exception("Cannot process more than 25 items")
+        raise ValueError("Received too many items (%s)" % len(items))
+
+    env_obj = get_environment(env)
+    profile = env_obj.aws_profile
+    table = env_obj.table
+
+    if delete:
+        request = {table: [{"DeleteRequest": {"Key": item} for item in items}]}
+        exc_msg = "Exception while deleting %s items from table '%s'"
+    else:
+        request = {table: [{"PutRequest": {"Item": item} for item in items}]}
+        exc_msg = "Exception while writing %s items to table '%s'"
+
+    try:
+        async with ddb_client(profile=profile) as ddb:
+            response = await ddb.batch_write_item(RequestItems=request)
+    except Exception:
+        LOG.exception(exc_msg, len(items), table)
+        raise
+
+    return response

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -45,6 +45,9 @@ class Settings(BaseSettings):
     db_service_port: str = "5432"
     """db service port"""
 
+    write_max_time: int = 60
+    """Maximum time for DynamoDB write operations."""
+
     class Config:
         env_prefix = "exodus_gw_"
 

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ psycopg2
 sqlalchemy
 async-exit-stack
 async-generator
+backoff

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,10 @@ attrs==20.3.0 \
     --hash=sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6 \
     --hash=sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700 \
     # via aiohttp
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4 \
+    # via -r requirements.in
 boto3==1.12.32 \
     --hash=sha256:57398de1b5e074e715c866441e69f90c9468959d5743a021d8aeed04fbaa1078 \
     --hash=sha256:60ac1124597231ed36a7320547cd0d16a001bb92333ab30ad20514f77e585225 \

--- a/tests/routers/test_dynamodb.py
+++ b/tests/routers/test_dynamodb.py
@@ -1,0 +1,109 @@
+import mock
+import pytest
+
+from exodus_gw.routers import dynamodb
+
+TEST_ITEMS = [
+    {"web_uri": {"S": "/example/one"}, "from_date": {"S": "2021-01-01"}},
+    {"web_uri": {"S": "/example/two"}, "from_date": {"S": "2021-01-01"}},
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delete,expected_request",
+    [
+        (False, {"PutRequest": {"Item": item} for item in TEST_ITEMS}),
+        (True, {"DeleteRequest": {"Key": item} for item in TEST_ITEMS}),
+    ],
+    ids=["Put", "Delete"],
+)
+async def test_batch_write(mock_aws_client, delete, expected_request):
+    """Ensure batch_write/delete delegates correctly to DynamoDB."""
+
+    # Represent successful write/delete of all items to the table.
+    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+
+    await dynamodb.batch_write("test", TEST_ITEMS, delete)
+
+    # Should've requested write of all items.
+    mock_aws_client.batch_write_item.assert_called_once_with(
+        RequestItems={"my-table": [expected_request]}
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_write_retry(mock_aws_client):
+    """Ensure batch_write is retried with unprocessed items."""
+
+    items = [
+        {"web_uri": {"S": "/example/one"}, "from_date": {"S": "2021-01-01"}},
+        {"web_uri": {"S": "/example/two"}, "from_date": {"S": "2021-01-01"}},
+    ]
+
+    # Represent successful write of all items after one retry.
+    mock_aws_client.batch_write_item.side_effect = [
+        {
+            "UnprocessedItems": {
+                "my-table": [{"PutRequest": {"Item": items[1]}}]
+            }
+        },
+        {"UnprocessedItems": {}},
+    ]
+
+    await dynamodb.batch_write("test", items)
+
+    # Should've requested write of all items, then retried one.
+    mock_aws_client.batch_write_item.assert_has_calls(
+        [
+            mock.call(
+                RequestItems={
+                    "my-table": [
+                        {"PutRequest": {"Item": item} for item in items}
+                    ]
+                }
+            ),
+            mock.call(
+                RequestItems={"my-table": [{"PutRequest": {"Item": items[1]}}]}
+            ),
+        ],
+        any_order=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_write_item_limit(mock_aws_client, caplog):
+    """Ensure batch_write does not accept more than 25 items."""
+
+    items = TEST_ITEMS * 13
+
+    with pytest.raises(ValueError) as exc:
+        await dynamodb.batch_write("test", items)
+
+    assert "Cannot process more than 25 items" in caplog.text
+    assert str(exc.value) == "Received too many items (26)"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delete,expected_msg",
+    [
+        (False, "Exception while writing 2 items to table 'my-table'"),
+        (True, "Exception while deleting 2 items from table 'my-table'"),
+    ],
+    ids=["Put", "Delete"],
+)
+async def test_batch_write_excs(mock_aws_client, delete, expected_msg, caplog):
+    """Ensure messages are emitted for exceptions."""
+
+    items = [
+        {"web_uri": {"S": "/example/one"}, "from_date": {"S": "2021-01-01"}},
+        {"web_uri": {"S": "/example/two"}, "from_date": {"S": "2021-01-01"}},
+    ]
+
+    mock_aws_client.batch_write_item.side_effect = ValueError()
+
+    with pytest.raises(ValueError):
+        await dynamodb.batch_write("test", items, delete)
+
+    assert expected_msg in caplog.text


### PR DESCRIPTION
This commit introduces a function to write and delete items on a
DynamoDB table with retry, exponential backoff, and jitter.

This function serves as a base for forthcoming exodus-gw endpoints.