### PR TITLE
Add isort to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 026c81b83454f176a9f9253cbfb70be2c159d822
+    rev: 20.8b1
     hooks:
     - id: black
+      language_version: python3.6
+-   repo: https://github.com/pycqa/isort/
+    rev: 5.6.4
+    hooks:
+    - id: isort
       language_version: python3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
-line_length = 88
+line_length = 79


### PR DESCRIPTION
Since isort standards are now enforced by CI, including it in pre-commit
will ensure related issues are dealt with locally rather than waiting
for failed Github checks.

- Added isort as a pre-commit hook
- Changed isort 'line_length' to match that of Black
- Updated hook revisions with 'pre-commit autoupdate'
- Ran 'pre-commit run --all-files' (all passed)