### PR TITLE
Introduce batch_write for DynamoDB [RHELDST-2161]

### DIFF
--- a/exodus_gw/aws/client.py
+++ b/exodus_gw/aws/client.py
@@ -78,3 +78,31 @@ class S3ClientWrapper:
         request_dict = kwargs.get("request_dict") or {}
         context = request_dict.get("context") or {}
         context["s3_redirected"] = True
+
+
+class DynamoDBClientWrapper:
+    """Helper class to obtain preconfigured DynamoDB clients.
+
+    Clients may be wrapped with additional config and event handlers.
+    """
+
+    def __init__(self, profile: str):
+        """Prepare a client for the given profile. This object must be used
+        via 'async with' in order to obtain access to the client.
+
+        Note: Session creation will fail if provided profile cannot be found.
+        """
+
+        session = aioboto3.Session(profile_name=profile)
+
+        self._client_context = session.client(
+            "dynamodb",
+            endpoint_url=os.environ.get("EXODUS_GW_DYNAMODB_ENDPOINT_URL")
+            or None,
+        )
+
+    async def __aenter__(self):
+        return await self._client_context.__aenter__()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._client_context.__aexit__(exc_type, exc, tb)

--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -1,0 +1,38 @@
+import logging
+from typing import List
+
+from ..aws.client import DynamoDBClientWrapper as ddb_client
+from ..settings import get_environment
+
+LOG = logging.getLogger("exodus-gw")
+
+
+async def batch_write(env: str, items: List[dict], delete: bool = False):
+    """Write or delete up to 25 items on the given environment's table.
+
+    Item limit of 25 is, at this time, imposed by AWS's boto3 library.
+    """
+
+    if len(items) > 25:
+        LOG.error("Cannot process more than 25 items")
+        raise ValueError("Received too many items (%s)" % len(items))
+
+    env_obj = get_environment(env)
+    profile = env_obj.aws_profile
+    table = env_obj.table
+
+    if delete:
+        request = {table: [{"DeleteRequest": {"Key": item} for item in items}]}
+        exc_msg = "Exception while deleting %s items from table '%s'"
+    else:
+        request = {table: [{"PutRequest": {"Item": item} for item in items}]}
+        exc_msg = "Exception while writing %s items to table '%s'"
+
+    try:
+        async with ddb_client(profile=profile) as ddb:
+            response = await ddb.batch_write_item(RequestItems=request)
+    except Exception:
+        LOG.exception(exc_msg, len(items), table)
+        raise
+
+    return response

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -1,0 +1,64 @@
+import pytest
+
+from exodus_gw.aws import dynamodb
+
+TEST_ITEMS = [
+    {"web_uri": {"S": "/example/one"}, "from_date": {"S": "2021-01-01"}},
+    {"web_uri": {"S": "/example/two"}, "from_date": {"S": "2021-01-01"}},
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delete,expected_request",
+    [
+        (False, {"PutRequest": {"Item": item} for item in TEST_ITEMS}),
+        (True, {"DeleteRequest": {"Key": item} for item in TEST_ITEMS}),
+    ],
+    ids=["Put", "Delete"],
+)
+async def test_batch_write(mock_aws_client, delete, expected_request):
+    """Ensure batch_write/delete delegates correctly to DynamoDB."""
+
+    # Represent successful write/delete of all items to the table.
+    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+
+    await dynamodb.batch_write("test", TEST_ITEMS, delete)
+
+    # Should've requested write of all items.
+    mock_aws_client.batch_write_item.assert_called_once_with(
+        RequestItems={"my-table": [expected_request]}
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_write_item_limit(mock_aws_client, caplog):
+    """Ensure batch_write does not accept more than 25 items."""
+
+    items = TEST_ITEMS * 13
+
+    with pytest.raises(ValueError) as exc:
+        await dynamodb.batch_write("test", items)
+
+    assert "Cannot process more than 25 items" in caplog.text
+    assert str(exc.value) == "Received too many items (26)"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delete,expected_msg",
+    [
+        (False, "Exception while writing 2 items to table 'my-table'"),
+        (True, "Exception while deleting 2 items from table 'my-table'"),
+    ],
+    ids=["Put", "Delete"],
+)
+async def test_batch_write_excs(mock_aws_client, delete, expected_msg, caplog):
+    """Ensure messages are emitted for exceptions."""
+
+    mock_aws_client.batch_write_item.side_effect = ValueError()
+
+    with pytest.raises(ValueError):
+        await dynamodb.batch_write("test", TEST_ITEMS, delete)
+
+    assert expected_msg in caplog.text


### PR DESCRIPTION
This commit introduces the batch_write function to write or delete
items on a DynamoDB table. A forthcoming endpoint will use this function
to "commit" publish items stored in the service database.