### PR TITLE
Fix batch_write put/delete requests

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -22,10 +22,10 @@ async def batch_write(env: str, items: List[dict], delete: bool = False):
     table = env_obj.table
 
     if delete:
-        request = {table: [{"DeleteRequest": {"Key": item} for item in items}]}
+        request = {table: [{"DeleteRequest": {"Key": item}} for item in items]}
         exc_msg = "Exception while deleting %s items from table '%s'"
     else:
-        request = {table: [{"PutRequest": {"Item": item} for item in items}]}
+        request = {table: [{"PutRequest": {"Item": item}} for item in items]}
         exc_msg = "Exception while writing %s items to table '%s'"
 
     try:

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -12,8 +12,48 @@ TEST_ITEMS = [
 @pytest.mark.parametrize(
     "delete,expected_request",
     [
-        (False, {"PutRequest": {"Item": item} for item in TEST_ITEMS}),
-        (True, {"DeleteRequest": {"Key": item} for item in TEST_ITEMS}),
+        (
+            False,
+            [
+                {
+                    "PutRequest": {
+                        "Item": {
+                            "web_uri": {"S": "/example/one"},
+                            "from_date": {"S": "2021-01-01"},
+                        }
+                    }
+                },
+                {
+                    "PutRequest": {
+                        "Item": {
+                            "web_uri": {"S": "/example/two"},
+                            "from_date": {"S": "2021-01-01"},
+                        }
+                    }
+                },
+            ],
+        ),
+        (
+            True,
+            [
+                {
+                    "DeleteRequest": {
+                        "Key": {
+                            "web_uri": {"S": "/example/one"},
+                            "from_date": {"S": "2021-01-01"},
+                        }
+                    }
+                },
+                {
+                    "DeleteRequest": {
+                        "Key": {
+                            "web_uri": {"S": "/example/two"},
+                            "from_date": {"S": "2021-01-01"},
+                        }
+                    }
+                },
+            ],
+        ),
     ],
     ids=["Put", "Delete"],
 )
@@ -27,7 +67,7 @@ async def test_batch_write(mock_aws_client, delete, expected_request):
 
     # Should've requested write of all items.
     mock_aws_client.batch_write_item.assert_called_once_with(
-        RequestItems={"my-table": [expected_request]}
+        RequestItems={"my-table": expected_request}
     )
 
 


### PR DESCRIPTION
Previously, the put/delete request contructor attempted to duplicate the
"Item" key. Since duplicating keys is not permitted in Python, this
resulted in the submission of only the last item from the given list.

This change corrects this bug, creating put/delete request dicts for
every item in the given list.