### PR TITLE
Implement commit_publish endpoint [RHELDST-2161]

### DIFF
--- a/exodus_gw/crud.py
+++ b/exodus_gw/crud.py
@@ -1,7 +1,7 @@
 from typing import List, Union
 
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session, lazyload
 
 from . import models, schemas
 
@@ -28,3 +28,14 @@ def update_publish(
         db.add(models.Item(**item.dict(), publish_id=publish_id))
 
     db.commit()
+
+
+def get_publish_by_id(
+    db: Session, publish_id: UUID
+) -> Query:  # pragma: no cover
+    return (
+        db.query(models.Publish)
+        .filter(models.Publish.id == publish_id)
+        .options(lazyload(models.Publish.items))
+        .first()
+    )

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -45,6 +45,11 @@ class Settings(BaseSettings):
     db_service_port: str = "5432"
     """db service port"""
 
+    batch_size: int = 25
+    """Maximum number of items to write at one time"""
+    max_tries: int = 20
+    """Maximum attempts to write to DynamoDB table."""
+
     class Config:
         env_prefix = "exodus_gw_"
 

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ psycopg2
 sqlalchemy
 async-exit-stack
 async-generator
+backoff

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,10 @@ attrs==20.3.0 \
     --hash=sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6 \
     --hash=sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700 \
     # via aiohttp
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4 \
+    # via -r requirements.in
 boto3==1.12.32 \
     --hash=sha256:57398de1b5e074e715c866441e69f90c9468959d5743a021d8aeed04fbaa1078 \
     --hash=sha256:60ac1124597231ed36a7320547cd0d16a001bb92333ab30ad20514f77e585225 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,3 +48,10 @@ def mock_item_list():
             from_date="2021-01-01T00:00:00.0",
         ),
     ]
+
+
+@pytest.fixture()
+def mock_publish(mock_item_list):
+    publish = schemas.Publish(id="123e4567-e89b-12d3-a456-426614174000")
+    publish.items = mock_item_list
+    yield publish

--- a/tests/routers/test_gateway.py
+++ b/tests/routers/test_gateway.py
@@ -1,8 +1,8 @@
 from types import GeneratorType
 
+import mock
 import pytest
 from fastapi import HTTPException
-from mock import MagicMock
 
 from exodus_gw import models
 from exodus_gw.routers import gateway
@@ -81,6 +81,141 @@ async def test_update_publish_items_env_doesnt_exist(
     assert exc_info.value.detail == "Invalid environment='foo'"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "env",
+    [
+        "test",
+        "test2",
+        "test3",
+    ],
+)
+@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+async def test_commit_publish(
+    mock_get_publish, env, mock_aws_client, mock_publish, mock_db_session
+):
+    mock_get_publish.return_value = mock_publish
+    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+
+    assert (
+        await gateway.commit_publish(
+            env=env, publish_id=mock_publish.id, db=mock_db_session
+        )
+        == {}
+    )
+
+
+@pytest.mark.asyncio
+@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+async def test_commit_publish_env_doesnt_exist(
+    mock_get_publish, mock_aws_client, mock_publish, mock_db_session
+):
+    mock_get_publish.return_value = mock_publish
+    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+
+    env = "foo"
+
+    with pytest.raises(HTTPException) as exc_info:
+        await gateway.commit_publish(
+            env=env, publish_id=mock_publish.id, db=mock_db_session
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Invalid environment='foo'"
+
+
+@pytest.mark.asyncio
+@mock.patch("exodus_gw.routers.gateway.batch_write")
+@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+async def test_commit_publish_write_failed(
+    mock_get_publish, mock_batch_write, mock_publish, mock_db_session, caplog
+):
+    mock_get_publish.return_value = mock_publish
+
+    fake_responses = {
+        "puts": {
+            "UnprocessedItems": {
+                "my-table": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "web_uri": "/some/path",
+                                "object_key": "abcde",
+                                "from_date": "2021-01-01T00:00:00.0",
+                            }
+                        }
+                    },
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "web_uri": "/other/path",
+                                "object_key": "a1b2",
+                                "from_date": "2021-01-01T00:00:00.0",
+                            }
+                        }
+                    },
+                ]
+            }
+        },
+        "deletes": {
+            "UnprocessedItems": {
+                "my-table": [
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "web_uri": "/some/path",
+                                "object_key": "abcde",
+                                "from_date": "2021-01-01T00:00:00.0",
+                            }
+                        }
+                    },
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "web_uri": "/other/path",
+                                "object_key": "a1b2",
+                                "from_date": "2021-01-01T00:00:00.0",
+                            }
+                        }
+                    },
+                ]
+            }
+        },
+    }
+
+    # Fail with successful cleanup.
+    mock_batch_write.side_effect = [
+        # Put unsuccessful.
+        fake_responses["puts"],
+        # Delete successful.
+        {"UnprocessedItems": {}},
+    ]
+
+    await gateway.commit_publish(
+        env="test", publish_id=mock_publish.id, db=mock_db_session
+    )
+
+    # Fail with unsuccessful cleanup.
+    mock_batch_write.side_effect = [
+        # Put unsuccessful.
+        fake_responses["puts"],
+        # Delete unsuccessful.
+        fake_responses["deletes"],
+    ]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await gateway.commit_publish(
+            env="test", publish_id=mock_publish.id, db=mock_db_session
+        )
+
+    assert (
+        "Unprocessed items:\n\t%s"
+        % str(fake_responses["deletes"]["UnprocessedItems"])
+        in caplog.text
+    )
+    assert "Cleanup failed" in str(exc_info.value)
+
+
 def test_whoami():
     # All work is done by fastapi deserialization, so this doesn't actually
     # do anything except return the passed object.
@@ -89,10 +224,12 @@ def test_whoami():
 
 
 def test_get_db(monkeypatch) -> None:
-    monkeypatch.setattr("exodus_gw.routers.gateway.SessionLocal", MagicMock())
+    monkeypatch.setattr(
+        "exodus_gw.routers.gateway.SessionLocal", mock.MagicMock()
+    )
 
     db = gateway.get_db()
     assert isinstance(db, GeneratorType)
 
     for session in db:
-        assert isinstance(session, MagicMock)
+        assert isinstance(session, mock.MagicMock)


### PR DESCRIPTION
This commit introduces a new endpoint used to commit the items stored on
existing publish objects to their place in the given environment's DynamoDB
table. Retry with exponential backoff and jitter was added to the
batch_write function.

The endpoint finds the publish based on the given publish_id,
divides the publish's items into appropriate batch sizes and executes
batch_write operations. Upon failure, the entire operation is aborted
and an attempt is made to delete what was written.