### PR TITLE
Correct s3 doc reference path

### DIFF
--- a/docs/api-guide.rst
+++ b/docs/api-guide.rst
@@ -32,7 +32,7 @@ Uploading blobs
 
 .. seealso:: `Upload API reference <api.html#tag/upload>`_
 
-.. automodule:: exodus_gw.s3.api
+.. automodule:: exodus_gw.routers.s3
 
 Using boto3 with the upload API
 ...............................


### PR DESCRIPTION
The location for the s3 module changed when exodus-gw was restructured
for the inclusion of additional AWS services.