### PR TITLE
Fix tag for publish API

### DIFF
--- a/exodus_gw/routers/gateway.py
+++ b/exodus_gw/routers/gateway.py
@@ -31,7 +31,7 @@ def healthcheck():
     "/{env}/publish",
     response_model=schemas.Publish,
     status_code=200,
-    tags=["service"],
+    tags=["publish"],
 )
 async def publish(env: str, db: Session = Depends(get_db)) -> models.Publish:
     """Returns a new, empty publish object"""


### PR DESCRIPTION
These tags are meant to help group related APIs in docs.
The "service" tag is meant for APIs such as healthcheck and whoami,
used for inspecting or debugging the exodus-gw service itself.

Publish-related APIs should use the "publish" tag.