### PR TITLE
dev env: use an environment file for customization

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -94,6 +94,25 @@ changes written to the DB and localstack), run:
   scripts/systemd/clean
 
 
+Configuration
+.............
+
+If you need to adjust the configuration of the development environment, such as
+using custom ports for services to avoid conflicts, you can edit the environment
+file at ``$HOME/.config/exodus-gw-dev/.env``.
+
+For example, if you need to run the development postgres server using a different
+port, you may add to this file:
+
+.. code-block:: shell
+
+  # use this port for postgres rather than default
+  EXODUS_GW_DB_SERVICE_PORT=8899
+
+The development environment installation process will generate a template file with
+the most useful environment variables listed.
+
+
 Cheat sheet
 ...........
 

--- a/scripts/systemd/exodus-gw-db.service
+++ b/scripts/systemd/exodus-gw-db.service
@@ -9,6 +9,7 @@ Wants=network.target
 After=network-online.target
 
 [Service]
+EnvironmentFile=-%S/exodus-gw-dev/.env
 Environment=EXODUS_GW_POSTGRES_IMAGE=quay.io/exodus/postgres:12
 Environment=EXODUS_GW_DB_SERVICE_PORT=3355
 

--- a/scripts/systemd/exodus-gw-localstack.service
+++ b/scripts/systemd/exodus-gw-localstack.service
@@ -9,6 +9,7 @@ Wants=network.target
 After=network-online.target exodus-gw-cert.service
 
 [Service]
+EnvironmentFile=-%S/exodus-gw-dev/.env
 Environment=EXODUS_GW_LOCALSTACK_IMAGE=quay.io/exodus/localstack:0.12.2
 Environment=EXODUS_GW_LOCALSTACK_PORT=3377
 

--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -10,6 +10,7 @@ Wants=network.target exodus-gw-uvicorn.service exodus-gw-cert.service
 After=network-online.target
 
 [Service]
+EnvironmentFile=-%S/exodus-gw-dev/.env
 Environment=EXODUS_GW_HTTP_PORT=8000
 Environment=EXODUS_GW_HTTPS_PORT=8010
 Environment=EXODUS_GW_SIDECAR_IMAGE=images.paas.redhat.com/enterprise-services/platform-sidecar:1.1.0

--- a/scripts/systemd/exodus-gw-uvicorn.service
+++ b/scripts/systemd/exodus-gw-uvicorn.service
@@ -4,6 +4,7 @@ Wants=network.target
 After=network-online.target exodus-gw-db.service
 
 [Service]
+EnvironmentFile=-%S/exodus-gw-dev/.env
 Environment=EXODUS_GW_HTTP_PORT=8000
 Environment=EXODUS_GW_SRC_PATH=%h/src/exodus-gw
 Environment=EXODUS_GW_DB_SERVICE_PORT=3355

--- a/scripts/systemd/install
+++ b/scripts/systemd/install
@@ -41,6 +41,35 @@ enable_units(){
   fi
 }
 
+create_env_file(){
+  # Create a .env file read by the rest of the units via EnvironmentFile.
+  # The main reason we need to do this is to ensure an accurate source path,
+  # since not every dev may clone the repo to the same location.
+  if ! test -f ~/.config/exodus-gw-dev/.env; then
+    mkdir -p ~/.config/exodus-gw-dev
+    cat >~/.config/exodus-gw-dev/.env <<END
+# Environment for exodus-gw development services.
+#
+# Arbitrary environment variables can be set here.
+# The most commonly used are listed here as examples.
+
+# Path to git repo
+EXODUS_GW_SRC_PATH=$(realpath -L ../..)
+
+# Port numbers for various things. You might have to change these
+# if you're having a clash with other services.
+#EXODUS_GW_DB_SERVICE_PORT=3355
+#EXODUS_GW_LOCALSTACK_PORT=3377
+#EXODUS_GW_HTTP_PORT=8000
+#EXODUS_GW_HTTPS_PORT=8010
+
+# You'll have to change this too if you change the localstack port.
+#EXODUS_GW_S3_ENDPOINT_URL=https://localhost:3377
+END
+  fi
+
+}
+
 make_cert(){
   systemctl --user start exodus-gw-cert.service
 }
@@ -79,6 +108,7 @@ END
 
 run(){
   check_prereqs
+  create_env_file
   enable_units
   make_cert
   summarize


### PR DESCRIPTION
Make all the systemd units load an EnvironmentFile so that we can
adjust the config by writing environment variables to that file.

The two main uses for this are:

1) To remove the requirement that this project must be cloned at
   ~/src/exodus-gw. That path was previously hardcoded in the units
   with no way of overriding; the accurate path is now generated in
   the EnvironmentFile so there is no hard dependency on the
   path of the checkout.

2) To provide a way to deal with port clashes, for the case where
   someone is already running a service on one of the ports used by
   the dev env.