### PR TITLE
devenv: tweak uvicorn args to avoid unnecessary reloads

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands=
 use_develop=true
 passenv=EXODUS_GW*
 commands=
-    uvicorn --reload exodus_gw.main:app {posargs}
+    uvicorn --reload --reload-dir exodus_gw exodus_gw.main:app {posargs}
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
The intent here is to reload automatically when code has changed,
so let's have it look under the directory containing the code only.

Without this, it'll look at '.', which means it'll frequently reload
as irrelevant files are changed (e.g. it'll watch files under .tox
and then reload if you run any tox command).