### PR TITLE
devenv: fix odd message due to copy-paste error in uninstall

### DIFF
--- a/scripts/systemd/uninstall
+++ b/scripts/systemd/uninstall
@@ -27,21 +27,9 @@ disable_units(){
   do_unit disable exodus-gw.target
 }
 
-summarize(){
-  cat <<END
-  do_unit disable exodus-gw-sidecar.service
-  do_unit disable exodus-gw.target
-}
-
-summarize(){
-  cat <<END
-exodus-gw units are uninstalled!
-END
-}
-
 run(){
   disable_units
-  summarize
+  echo 'exodus-gw units are uninstalled!'
 }
 
 run


### PR DESCRIPTION
The uninstall script seems to have had either a copy-paste or
conflict resolution error, with a few lines being duplicated.
Since we are only trying to echo a single line, usage of a heredoc
is probably overkill anyway.