### PR TITLE
Commit publish entry point files last [RHELDST-2161]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -50,6 +50,13 @@ class Settings(BaseSettings):
     max_tries: int = 20
     """Maximum attempts to write to DynamoDB table."""
 
+    entry_point_files: List[str] = [
+        "repomd.xml",
+        "repomd.xml.asc",
+        "PULP_MANIFEST",
+    ]
+    """List of file names that should be saved for last when publishing."""
+
     class Config:
         env_prefix = "exodus_gw_"
 

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -1,3 +1,6 @@
+import logging
+
+import mock
 import pytest
 
 from exodus_gw.aws import dynamodb
@@ -9,49 +12,71 @@ from exodus_gw.aws import dynamodb
     [
         (
             False,
-            [
-                {
-                    "PutRequest": {
-                        "Item": {
-                            "web_uri": {"S": "/some/path"},
-                            "object_key": {"S": "abcde"},
-                            "from_date": {"S": "2021-01-01T00:00:00.0"},
+            {
+                "my-table": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "web_uri": {"S": "/some/path"},
+                                "object_key": {"S": "abcde"},
+                                "from_date": {"S": "2021-01-01T00:00:00.0"},
+                            }
                         }
-                    }
-                },
-                {
-                    "PutRequest": {
-                        "Item": {
-                            "web_uri": {"S": "/other/path"},
-                            "object_key": {"S": "a1b2"},
-                            "from_date": {"S": "2021-01-01T00:00:00.0"},
+                    },
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "web_uri": {"S": "/other/path"},
+                                "object_key": {"S": "a1b2"},
+                                "from_date": {"S": "2021-01-01T00:00:00.0"},
+                            }
                         }
-                    }
-                },
-            ],
+                    },
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "web_uri": {"S": "/to/repomd.xml"},
+                                "object_key": {"S": "c3d4"},
+                                "from_date": {"S": "2021-01-01T00:00:00.0"},
+                            }
+                        }
+                    },
+                ],
+            },
         ),
         (
             True,
-            [
-                {
-                    "DeleteRequest": {
-                        "Key": {
-                            "web_uri": {"S": "/some/path"},
-                            "object_key": {"S": "abcde"},
-                            "from_date": {"S": "2021-01-01T00:00:00.0"},
+            {
+                "my-table": [
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "web_uri": {"S": "/some/path"},
+                                "object_key": {"S": "abcde"},
+                                "from_date": {"S": "2021-01-01T00:00:00.0"},
+                            }
                         }
-                    }
-                },
-                {
-                    "DeleteRequest": {
-                        "Key": {
-                            "web_uri": {"S": "/other/path"},
-                            "object_key": {"S": "a1b2"},
-                            "from_date": {"S": "2021-01-01T00:00:00.0"},
+                    },
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "web_uri": {"S": "/other/path"},
+                                "object_key": {"S": "a1b2"},
+                                "from_date": {"S": "2021-01-01T00:00:00.0"},
+                            }
                         }
-                    }
-                },
-            ],
+                    },
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "web_uri": {"S": "/to/repomd.xml"},
+                                "object_key": {"S": "c3d4"},
+                                "from_date": {"S": "2021-01-01T00:00:00.0"},
+                            }
+                        }
+                    },
+                ],
+            },
         ),
     ],
     ids=["Put", "Delete"],
@@ -59,48 +84,103 @@ from exodus_gw.aws import dynamodb
 async def test_batch_write(
     mock_aws_client, mock_publish, delete, expected_request
 ):
-    """Ensure batch_write/delete delegates correctly to DynamoDB."""
+    request = dynamodb.create_request("test", mock_publish.items, delete)
 
     # Represent successful write/delete of all items to the table.
     mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
-    await dynamodb.batch_write("test", mock_publish.items, delete)
+    await dynamodb.batch_write("test", request)
 
     # Should've requested write of all items.
     mock_aws_client.batch_write_item.assert_called_once_with(
-        RequestItems={"my-table": expected_request}
+        RequestItems=expected_request
     )
 
 
 @pytest.mark.asyncio
 async def test_batch_write_item_limit(mock_aws_client, mock_publish, caplog):
-    """Ensure batch_write does not accept more than 25 items."""
-
-    items = mock_publish.items * 13
+    items = mock_publish.items * 9
+    request = dynamodb.create_request("test", items)
 
     with pytest.raises(ValueError) as exc_info:
-        await dynamodb.batch_write("test", items)
+        await dynamodb.batch_write("test", request)
 
-    assert "Cannot process more than 25 items" in caplog.text
-    assert str(exc_info.value) == "Received too many items (26)"
+    assert "Cannot process more than 25 items per request" in caplog.text
+    assert str(exc_info.value) == "Request contains too many items (27)"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "delete,expected_msg",
-    [
-        (False, "Exception while writing 2 items to table 'my-table'"),
-        (True, "Exception while deleting 2 items from table 'my-table'"),
-    ],
-    ids=["Put", "Delete"],
-)
-async def test_batch_write_excs(
-    mock_aws_client, mock_publish, delete, expected_msg, caplog
-):
-    """Ensure messages are emitted for exceptions."""
+@pytest.mark.parametrize("delete", [False, True], ids=["Put", "Delete"])
+async def test_write_batches(delete, mock_aws_client, mock_publish, caplog):
+    caplog.set_level(logging.INFO, logger="exodus-gw")
+    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
 
+    expected_msg = "Items successfully %s" % "deleted" if delete else "written"
+
+    assert (
+        await dynamodb.write_batches("test", mock_publish.items, delete)
+        is True
+    )
+
+    assert expected_msg in caplog.text
+
+
+@pytest.mark.asyncio
+@mock.patch("exodus_gw.aws.dynamodb.batch_write")
+async def test_write_batches_put_fail(mock_batch_write, mock_publish, caplog):
+    caplog.set_level(logging.INFO, logger="exodus-gw")
+    mock_batch_write.return_value = {
+        "UnprocessedItems": {
+            "my-table": [
+                {"PutRequest": {"Item": mock_publish.items[1].aws_fmt}},
+            ]
+        }
+    }
+
+    assert await dynamodb.write_batches("test", mock_publish.items) is False
+
+    assert "One or more writes were unsuccessful" in caplog.text
+
+
+@pytest.mark.asyncio
+@mock.patch("exodus_gw.aws.dynamodb.batch_write")
+async def test_write_batches_delete_fail(
+    mock_batch_write, mock_publish, caplog
+):
+    mock_batch_write.return_value = {
+        "UnprocessedItems": {
+            "my-table": [
+                {"PutRequest": {"Key": mock_publish.items[1].aws_fmt}},
+            ]
+        }
+    }
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await dynamodb.write_batches("test", mock_publish.items, delete=True)
+
+    assert (
+        "Unprocessed items:\n\t%s"
+        % str(
+            {
+                "my-table": [
+                    {"PutRequest": {"Key": mock_publish.items[1].aws_fmt}},
+                ]
+            }
+        )
+        in caplog.text
+    )
+    assert "Deletion failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delete", [False, True], ids=["Put", "Delete"])
+async def test_write_batches_excs(
+    mock_aws_client, mock_publish, delete, caplog
+):
     mock_aws_client.batch_write_item.side_effect = ValueError()
 
+    expected_msg = "Exception while %s" % "deleting" if delete else "writing"
+
     with pytest.raises(ValueError):
-        await dynamodb.batch_write("test", mock_publish.items, delete)
+        await dynamodb.write_batches("test", mock_publish.items, delete)
 
     assert expected_msg in caplog.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,11 @@ def mock_item_list():
             object_key="a1b2",
             from_date="2021-01-01T00:00:00.0",
         ),
+        schemas.ItemBase(
+            web_uri="/to/repomd.xml",
+            object_key="c3d4",
+            from_date="2021-01-01T00:00:00.0",
+        ),
     ]
 
 


### PR DESCRIPTION
Adds functionality to only commit publish items with certain file names
(configurable in settings) when all other items are successfully published.

Additionally, batch_write was simplified to a wrapper for
batch_write_items and a new function, write_batches, was introduced to
handle successive calls to batch_write.