### PR TITLE
Fix dramatiq SQL missing from exodus_gw egg & image

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include CHANGELOG.md
 include LICENSE
 include requirements.txt
 include requirements.in
+recursive-include exodus_gw *.sql

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name="exodus-gw",
     version="0.0.1",
     packages=find_packages(exclude=["tests"]),
-    package_data={},
+    include_package_data=True,
     url="https://github.com/release-engineering/exodus-gw",
     license="GNU General Public License",
     description=get_description(),


### PR DESCRIPTION
Data files alongside python packages don't get processed by
setuptools by default. This led to the SQL file containing dramatiq
schema to be missed from the python egg (and therefore the container
image).

Tweak packaging metadata to ensure the file is included.