### PR TITLE
cleanup: drop unnecessary constructors from models

### DIFF
--- a/exodus_gw/models.py
+++ b/exodus_gw/models.py
@@ -20,9 +20,6 @@ class Publish(Base):
     )
     items = relationship("Item", back_populates="publish")
 
-    def __init__(self):
-        pass
-
 
 class Item(Base):
 
@@ -43,15 +40,3 @@ class Item(Base):
     )
 
     publish = relationship("Publish", back_populates="items")
-
-    def __init__(
-        self,
-        web_uri=web_uri,
-        object_key=object_key,
-        from_date=from_date,
-        publish_id=publish_id,
-    ):
-        self.web_uri = web_uri
-        self.object_key = object_key
-        self.from_date = from_date
-        self.publish_id = publish_id


### PR DESCRIPTION
One of the features included in DeclarativeBase is the implicit
generation of constructors with keywords matching attributes on
the models.  We don't need to define constructors ourselves, and
it's probably best to avoid doing that since it could lead to
inconsistencies such as forgetting an attribute in one place or
the other.