### PR TITLE
Fix model/schema type errors

### DIFF
--- a/exodus_gw/models.py
+++ b/exodus_gw/models.py
@@ -44,6 +44,14 @@ class Item(Base):
 
     publish = relationship("Publish", back_populates="items")
 
+    @property
+    def aws_fmt(self):
+        return {
+            "web_uri": {"S": self.web_uri},
+            "object_key": {"S": self.object_key},
+            "from_date": {"S": self.from_date},
+        }
+
     def __init__(
         self,
         web_uri=web_uri,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.session import Session
 # anything from the exodus_gw.worker module.
 os.environ["EXODUS_GW_STUB_BROKER"] = "1"
 
-from exodus_gw import schemas  # noqa
+from exodus_gw import models, schemas  # noqa
 
 
 @pytest.fixture(autouse=True)
@@ -59,8 +59,12 @@ def mock_item_list():
 
 @pytest.fixture()
 def mock_publish(mock_item_list):
-    publish = schemas.Publish(id="123e4567-e89b-12d3-a456-426614174000")
-    publish.items = mock_item_list
+    publish = models.Publish()
+    publish.id = "123e4567-e89b-12d3-a456-426614174000"
+    publish.items = [
+        models.Item(**item.dict(), publish_id=publish.id)
+        for item in mock_item_list
+    ]
     yield publish
 
 


### PR DESCRIPTION
This commit corrects a few type inconsistencies between dicts, model
objects, and schema objects.

As the way in which put and delete requests are constructed needed to
change as a result, an 'aws_fmt' property was added to the Item model for
convenience when constructing said requests.