### PR TITLE
dev env: support usage of dynamodb in localstack

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -182,19 +182,44 @@ the development environment.
 
        - Other parameters can be omitted.
 
-   * - ``aws --endpoint-url=https://localhost:3377 s3api create-bucket --bucket my-bucket``
+   * - ``scripts/localstack-s3-init``
+
+       ``scripts/localstack-s3-init some-bucket``
+
      - Create a bucket in localstack.
 
        The localstack environment is initially empty, which will make it impossible to
        upload any objects. For upload to work with exodus-gw, you'll want to create one
-       or more buckets matching the info in ``exodus-gw.ini``.
+       or more buckets matching the info in ``exodus-gw.ini``. The script will make a bucket
+       matching the ``test`` environment if no name is specified.
+
+   * - ``scripts/localstack-dynamodb-init``
+
+       ``scripts/localstack-dynamodb-init some-table``
+
+     - Create a table in localstack.
+
+       The localstack environment is initially empty, which will make it impossible to
+       execute any publish tasks. For publish to work with exodus-gw, you'll want to create
+       one or more tables matching the info in ``exodus-gw.ini``. The script will make a table
+       matching the ``test`` environment if no name is specified.
+
+   * - ``aws --endpoint-url=https://localhost:3377 s3 ls s3://my-bucket``
+     - List files in localstack s3 bucket.
+
+       Can be used to check the outcome of an upload.
+
+   * - ``aws --endpoint-url=https://localhost:3377 dynamodb scan --table-name my-table``
+     - Dump all content of a dynamodb table in localstack.
+
+       Can be used to check the outcome of a publish.
 
    * - ``examples/s3-upload --endpoint-url https://localhost:8010/upload --env test some-file``
      - Upload an object via exodus-gw.
 
        This will write to the localstack service.
        If you're not sure whether anything really happened, check the logs of
-       exodus-gw-localstack.service.
+       exodus-gw-localstack.service or use the ``s3 ls`` command above.
 
    * - ``psql -h localhost -p 3355 -U exodus-gw``
      - Connect to the postgres database.

--- a/scripts/localstack-dynamodb-init
+++ b/scripts/localstack-dynamodb-init
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Create a dynamodb table in the dev env's localstack instance.
+#
+# You will need to run this when:
+# - initially creating the dev env, or
+# - after cleaning it, or
+# - if you want to use a different table
+#
+
+# should match table for the environment you want to use in exodus-gw.ini
+TABLE_NAME="${1:-my-table}"
+
+ENV_FILE="~/.config/exodus-gw-dev/.env"
+
+if test -f "$ENV_FILE"; then
+  . "$ENV_FILE"
+fi
+
+set -xe
+
+exec aws \
+  --endpoint-url="${EXODUS_GW_DYNAMODB_ENDPOINT_URL:-https://localhost:3377}" \
+   dynamodb \
+   create-table \
+   --table-name "${TABLE_NAME}" \
+  --attribute-definitions AttributeName=web_uri,AttributeType=S \
+                          AttributeName=from_date,AttributeType=S \
+  --key-schema AttributeName=web_uri,KeyType=HASH \
+               AttributeName=from_date,KeyType=RANGE \
+  --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10

--- a/scripts/localstack-s3-init
+++ b/scripts/localstack-s3-init
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Create an s3 bucket in the dev env's localstack instance.
+#
+# You will need to run this when:
+# - initially creating the dev env, or
+# - after cleaning it, or
+# - if you want to use a different bucket
+#
+
+# should match bucket for the environment you want to use in exodus-gw.ini
+BUCKET_NAME="${1:-my-bucket}"
+
+ENV_FILE="~/.config/exodus-gw-dev/.env"
+
+if test -f "$ENV_FILE"; then
+  . "$ENV_FILE"
+fi
+
+set -xe
+
+exec aws \
+  --endpoint-url="${EXODUS_GW_S3_ENDPOINT_URL:-https://localhost:3377}" \
+  s3api \
+  create-bucket \
+  --bucket "${BUCKET_NAME}"

--- a/scripts/systemd/exodus-gw-localstack.service
+++ b/scripts/systemd/exodus-gw-localstack.service
@@ -41,7 +41,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n-pid --cidfile %t/%n-cid --c
   --log-driver journald\
   -v %S/exodus-gw-dev/localstack:/tmp/localstack:z\
   -e DATA_DIR=/tmp/localstack/data\
-  -e SERVICES=s3\
+  -e SERVICES=s3,dynamodb\
   -e DEBUG=1\
   -e EDGE_PORT=${EXODUS_GW_LOCALSTACK_PORT}\
   ${EXODUS_GW_LOCALSTACK_IMAGE}

--- a/scripts/systemd/exodus-gw-uvicorn.service
+++ b/scripts/systemd/exodus-gw-uvicorn.service
@@ -10,6 +10,7 @@ Environment=EXODUS_GW_SRC_PATH=%h/src/exodus-gw
 Environment=EXODUS_GW_DB_SERVICE_PORT=3355
 Environment=EXODUS_GW_DB_SERVICE_HOST=localhost
 Environment=EXODUS_GW_S3_ENDPOINT_URL=https://localhost:3377
+Environment=EXODUS_GW_DYNAMODB_ENDPOINT_URL=https://localhost:3377
 Restart=on-failure
 
 ExecStart=/bin/sh -c "cd ${EXODUS_GW_SRC_PATH}; \

--- a/scripts/systemd/exodus-gw-worker.service
+++ b/scripts/systemd/exodus-gw-worker.service
@@ -8,6 +8,7 @@ EnvironmentFile=-%S/exodus-gw-dev/.env
 Environment=EXODUS_GW_SRC_PATH=%h/src/exodus-gw
 Environment=EXODUS_GW_DB_SERVICE_PORT=3355
 Environment=EXODUS_GW_DB_SERVICE_HOST=localhost
+Environment=EXODUS_GW_DYNAMODB_ENDPOINT_URL=https://localhost:3377
 Restart=on-failure
 
 ExecStart=/bin/sh -c "cd ${EXODUS_GW_SRC_PATH}; \


### PR DESCRIPTION
The dynamodb service in localstack seems to work just fine, so
let's enable it and start making use of it.

It's necessary to create a table before this will work. Because
the command for that is somewhat cumbersome, it was wrapped up
in a helper script; the same thing was done for s3 for consistency.

Docs now contain a few additional commands which can be used to
check the state of s3 & dynamodb within localstack.