### PR TITLE
Allow upload of empty files [RHELDST-4728]

### DIFF
--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -5,6 +5,20 @@ from defusedxml.ElementTree import fromstring
 from fastapi import Response
 
 
+def content_md5(request):
+    """Produce ContentMD5 value expected by S3 APIs.
+
+    When uploading empty files, the Content-MD5 header may not be
+    included in the request when content length is 0. In such cases,
+    return the appropriate base64 encoded md5.
+    """
+
+    if int(request.headers["Content-Length"]) == 0:
+        return "1B2M2Y8AsgTpgAmY7PhCfg=="
+
+    return request.headers["Content-MD5"]
+
+
 def extract_mpu_parts(
     body: str, xmlns: str = "http://s3.amazonaws.com/doc/2006-03-01/"
 ):

--- a/exodus_gw/routers/s3.py
+++ b/exodus_gw/routers/s3.py
@@ -35,7 +35,12 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
 
 from ..aws.client import S3ClientWrapper as s3_client
-from ..aws.util import RequestReader, extract_mpu_parts, xml_response
+from ..aws.util import (
+    RequestReader,
+    content_md5,
+    extract_mpu_parts,
+    xml_response,
+)
 from ..settings import get_environment
 
 LOG = logging.getLogger("s3")
@@ -160,7 +165,7 @@ async def object_put(env: str, key: str, request: Request):
             Bucket=env_obj.bucket,
             Key=key,
             Body=reader,
-            ContentMD5=request.headers["Content-MD5"],
+            ContentMD5=content_md5(request),
             ContentLength=int(request.headers["Content-Length"]),
         )
 
@@ -223,7 +228,7 @@ async def multipart_put(
             Key=key,
             PartNumber=partNumber,
             UploadId=uploadId,
-            ContentMD5=request.headers["Content-MD5"],
+            ContentMD5=content_md5(request),
             ContentLength=int(request.headers["Content-Length"]),
         )
 

--- a/tests/aws/test_content_md5.py
+++ b/tests/aws/test_content_md5.py
@@ -1,0 +1,14 @@
+import mock
+
+from exodus_gw.aws.util import content_md5
+
+
+def test_empty_content_md5():
+    """When the Content-Length header is 0, no Content-MD5 is present
+    and content_md5 returns equivalent value for no content.
+    """
+
+    request = mock.MagicMock()
+    request.headers = {"Content-Length": 0}
+
+    assert content_md5(request) == "1B2M2Y8AsgTpgAmY7PhCfg=="


### PR DESCRIPTION
No Content-MD5 header is added to upload requests for files which have
no content. This caused a key error in our code, so a static value was
added for empty files, matching that which would be generated.