### PR TITLE
Migrate container image & CI from python 3.6 => 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ jobs:
     script:
     - docker --version
     - docker build . -f openshift/containers/exodus-gw/Dockerfile
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=cov-travis
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=static
-  - python: "3.6"
+  - python: "3.8"
     env: TOX_ENV=docs
 
 script: 

--- a/openshift/containers/exodus-gw/Dockerfile
+++ b/openshift/containers/exodus-gw/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     # Install shadow-utils for adduser functionality
     microdnf -y install shadow-utils \
     # Install extra commands needed for build
-    && microdnf -y install python3 python3-devel gcc make \
+    && microdnf -y install python38 python38-devel gcc make \
     # Install packages needed for psycopg2 installation
     && microdnf -y install postgresql-devel \
     && cd /usr/local/src/exodus-gw \

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ aioboto3
 defusedxml
 uvicorn[standard]
 gunicorn
-dataclasses;python_version<'3.7'
 psycopg2
 sqlalchemy
 async-exit-stack

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,12 +98,6 @@ click==7.1.2 \
     --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a \
     --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc
     # via uvicorn
-dataclasses==0.7 ; python_version < "3.7" \
-    --hash=sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836 \
-    --hash=sha256:494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6
-    # via
-    #   -r requirements.in
-    #   pydantic
 defusedxml==0.6.0 \
     --hash=sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93 \
     --hash=sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5
@@ -224,15 +218,10 @@ httptools==0.1.1 \
     --hash=sha256:fa3cd71e31436911a44620473e873a256851e1f53dee56669dae403ba41756a4 \
     --hash=sha256:fea04e126014169384dee76a153d4573d90d0cbd1d12185da089f73c78390437
     # via uvicorn
-idna-ssl==1.1.0 \
-    --hash=sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c
-    # via aiohttp
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
-    # via
-    #   idna-ssl
-    #   yarl
+    # via yarl
 jmespath==0.10.0 \
     --hash=sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9 \
     --hash=sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f
@@ -430,8 +419,6 @@ typing-extensions==3.7.4.3 \
     # via
     #   aiohttp
     #   aioitertools
-    #   uvicorn
-    #   yarl
 urllib3==1.25.11 \
     --hash=sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2 \
     --hash=sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     install_requires=get_requirements(),
-    python_requires=">=3",
+    python_requires=">=3.8",
     project_urls={
         "Documentation": "https://release-engineering.github.io/exodus-gw",
     },

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -98,12 +98,6 @@ coveralls==3.0.0 \
     --hash=sha256:5399c0565ab822a70a477f7031f6c88a9dd196b3de2877b3facb43b51bd13434 \
     --hash=sha256:f8384968c57dee4b7133ae701ecdad88e85e30597d496dcba0d7fbb470dca41f
     # via -r test-requirements.in
-dataclasses==0.7 ; python_version < "3.7" \
-    --hash=sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836 \
-    --hash=sha256:494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6
-    # via
-    #   -r test-requirements.in
-    #   black
 docopt==0.6.2 \
     --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
     # via coveralls
@@ -129,11 +123,7 @@ imagesize==1.2.0 \
 importlib-metadata==3.4.0 \
     --hash=sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771 \
     --hash=sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d
-    # via
-    #   -r test-requirements.in
-    #   flake8
-    #   pluggy
-    #   pytest
+    # via -r test-requirements.in
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -416,16 +406,12 @@ typed-ast==1.4.2 \
     --hash=sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3 \
     --hash=sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166 \
     --hash=sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10
-    # via
-    #   astroid
-    #   black
+    # via black
 typing-extensions==3.7.4.3 \
     --hash=sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918 \
     --hash=sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c \
     --hash=sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f
-    # via
-    #   black
-    #   importlib-metadata
+    # via black
 urllib3==1.25.11 \
     --hash=sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2 \
     --hash=sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py36, py37, static, docs
-skip_missing_interpreters = true
+envlist = py38, static, docs
 
 [testenv]
 deps=


### PR DESCRIPTION
Python 3.8 is available for UBI8. Let's update to that,
from python 3.6.

The motivations for this include:

- generally keeping up-to-date with modern python

- enabling usage of the contextvars feature [1] introduced in
  python 3.7.  As we are using a web framework which supports
  asyncio, some challenges can arise which are difficult to
  solve without access to something like contextvars.

CI and tox environments were also updated to use python 3.8
and requirements files were recompiled for python 3.8, changing
the set of requirements slightly.  One dependency needed only
for python<=3.6 was dropped.

[1] https://docs.python.org/3/library/contextvars.html