### PR TITLE
Share transactions between sqlalchemy and dramatiq [RHELDST-4715]

### DIFF
--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -1,5 +1,6 @@
 import logging.config
 
+import dramatiq
 from fastapi import FastAPI, Request
 from fastapi.exception_handlers import http_exception_handler
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -54,19 +55,25 @@ def db_init() -> None:
 
 @app.middleware("http")
 async def db_session(request: Request, call_next):
-    """Maintain a DB session around each request.
+    """Maintain a DB session around each request, which is also shared
+    with the dramatiq broker.
 
     An implicit commit occurs if and only if the request succeeds.
     """
 
     request.state.db = SessionLocal()
 
-    response = await call_next(request)
+    # Any dramatiq operations should also make use of this session.
+    broker = dramatiq.get_broker()
+    broker.set_session(request.state.db)
 
-    if response.status_code >= 200 and response.status_code < 300:
-        request.state.db.commit()
-
-    request.state.db.close()
-    request.state.db = None
+    try:
+        response = await call_next(request)
+        if response.status_code >= 200 and response.status_code < 300:
+            request.state.db.commit()
+    finally:
+        broker.set_session(None)
+        request.state.db.close()
+        request.state.db = None
 
     return response

--- a/exodus_gw/worker/broker.py
+++ b/exodus_gw/worker/broker.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from contextvars import ContextVar
 
 import dramatiq_pg
 from dramatiq.brokers.stub import StubBroker
@@ -15,6 +16,51 @@ LOG = logging.getLogger("exodus-gw")
 SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "schema.sql")
 
 
+class SessionPoolAdapter:
+    """Adapts an sqlalchemy session into a connection pool compatible
+    with dramatiq-pg.
+    """
+
+    def __init__(self, session):
+        self._session = session
+
+    def execute(self, statement, parameters=None):
+        # When requested to execute a statement, we go through sqlalchemy
+        # so that we're sharing the same connection & transaction as the ORM.
+        #
+        # Note: change this to Connection.exec_driver_sql()
+        # once we are on sqlalchemy >= 1.4
+        return self._session.connection().execute(statement, parameters)
+
+    # The empty implementations of below methods effectively cause us to ignore
+    # requests to begin or end any transactions - we want to always leave that
+    # up to the sqlalchemy session.
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+    def cursor(self):
+        return self
+
+
+class NoSessionAvailable:
+    """Helper to raise a meaningful error if broker is unexpectedly used outside
+    the context of an sqlalchemy session.
+    """
+
+    def __enter__(self):
+        raise RuntimeError(
+            "BUG: attempted to use session-aware broker while no session is active!"
+        )
+
+    def __exit__(self, *_):
+        # If __exit__ is not implemented, we get a crash during tests, yet pytest-cov
+        # believes that this is not covered - not sure what's the deal here.
+        pass  # pragma: no cover
+
+
 class ExodusGwBroker(
     dramatiq_pg.PostgresBroker
 ):  # pylint: disable=abstract-method
@@ -22,11 +68,46 @@ class ExodusGwBroker(
 
     - uses DB from settings by default, same as rest of exodus-gw
     - initializes required tables on first use
+    - can join the broker to an existing sqlalchemy session
     """
 
     def __init__(self, url=SQLALCHEMY_DATABASE_URL, pool=None):
+        # Since we only have one globally shared broker, but
+        # we want to connect with an sqlalchemy session which is
+        # specific to one coro, we'll make a context-aware wrapper
+        # for pool.
+        self.__pool = ContextVar("pool")
+
         # Uses the same DB as used for sqlalchemy by default.
         super().__init__(url=url, pool=pool)
+
+    @property
+    def pool(self):
+        return self.__pool.get()
+
+    @pool.setter
+    def pool(self, value):
+        self.__pool.set(value)
+
+    def set_session(self, session):
+        """Set an sqlalchemy session for use with the broker.
+
+        - When first constructed, the broker manages its own connection and transactions
+          with postgres.
+
+        - If set_session is called with a session, the broker will execute all subsequent
+          SQL statements via that session, and will no longer perform any management of
+          transactions (any COMMIT or ROLLBACK must occur externally from the broker).
+
+        - If set_session is called with None, the broker becomes unusable until another
+          session is set, i.e. if you use the broker with a session once, you must continue
+          to use it that way permanently. This is enforced to avoid mixing session-aware
+          and non-session-aware usage of the broker which would be a source of bugs.
+        """
+        if session:
+            self.pool = SessionPoolAdapter(session)
+        else:
+            self.pool = NoSessionAvailable()
 
     def __ensure_init(self):
         with open(SCHEMA_PATH, "rt") as f:
@@ -50,13 +131,24 @@ class ExodusGwBroker(
         return super().consume(*args, **kwargs)
 
 
+class ExodusGwStubBroker(StubBroker):
+    def __init__(self):
+        super().__init__()
+        # Default stub broker doesn't enable any results backend by default,
+        # while we need one
+        self.add_middleware(Results(backend=StubBackend()))
+
+    def set_session(self, _session):
+        # Implement a no-op for this method just to be API compatible
+        # with the real broker.
+        pass
+
+
 def new_broker():
     # As recommended in dramatiq docs, returns a StubBroker if we are
     # currently running tests. This env var is set in conftest.py prior
     # to import.
     if os.getenv("EXODUS_GW_STUB_BROKER") == "1":
-        out = StubBroker()
-        out.add_middleware(Results(backend=StubBackend()))
-        return out
+        return ExodusGwStubBroker()
 
     return ExodusGwBroker()

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -1,8 +1,5 @@
 import mock
-import pytest
-from fastapi import HTTPException
 
-from exodus_gw import models
 from exodus_gw.routers import service
 
 
@@ -14,7 +11,7 @@ def test_healthcheck_worker(stub_worker):
     # This test exercises "real" dramatiq message handling via stub
     # broker & worker, demonstrating that messages can be used from
     # within tests.
-    assert service.healthcheck_worker() == {
+    assert service.healthcheck_worker(db=mock.Mock()) == {
         "detail": "background worker is running: ping => pong"
     }
 


### PR DESCRIPTION
Each HTTP request is wrapped in a transaction.

Previously, this transaction covered only the sqlalchemy ORM.
It is advantageous to also let the dramatiq broker share the
same transaction, so that when an HTTP request handler runs code
such as:

  x = SomeNewObject()
  db.add(x)              # persist object to DB
  some_actor.send(x.id)  # enqueue dramatiq message in DB

...we can be confident that either *both* the ORM and dramatiq
changes were persisted, or *neither*.  Without this, our code would
be vulnerable to edge cases where one of these operations could
succeed and the other fail.

Although we were already using postgres for both sqlalchemy and
dramatiq, the two libraries managed their own DB connections, and
so wouldn't participate in the same transaction.

This commit fixes that by bridging the two libraries: our custom
broker can have an sqlalchemy session injected, and if so, dramatiq
executes all SQL via that session. The solution is asyncio-aware
so it can be safely used from multiple request handlers
concurrently.

One implication of this change is that a call to '.send' on an actor
won't actually send a message until commit occurs - which, by
default, means it's not sent until the HTTP request succeeds.
If we want to block on a reply, as in the healthcheck-worker example,
we need to explicitly commit so that messages are sent.

Note also that the transaction sharing is designed for use in the
web app only - any code running within a dramatiq worker is still
expected to use the broker in its default configuration without
setting a session.