### PR TITLE
refactor: reorganize endpoints into appropriate set of modules

### DIFF
--- a/docs/api-guide.rst
+++ b/docs/api-guide.rst
@@ -32,7 +32,7 @@ Uploading blobs
 
 .. seealso:: `Upload API reference <api.html#tag/upload>`_
 
-.. automodule:: exodus_gw.routers.s3
+.. automodule:: exodus_gw.routers.upload
 
 Using boto3 with the upload API
 ...............................

--- a/exodus_gw/database.py
+++ b/exodus_gw/database.py
@@ -1,3 +1,4 @@
+from fastapi import Request
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -14,3 +15,8 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
+
+def get_db(request: Request):
+    """DB session accessor for use with FastAPI's dependency injection system."""
+    return request.state.db

--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -7,12 +7,13 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from . import models
 from .aws.util import xml_response
 from .database import SessionLocal
-from .routers import gateway, s3
+from .routers import publish, service, upload
 from .settings import get_settings
 
 app = FastAPI(title="exodus-gw")
-app.include_router(gateway.router)
-app.include_router(s3.router)
+app.include_router(service.router)
+app.include_router(upload.router)
+app.include_router(publish.router)
 
 
 @app.exception_handler(StarletteHTTPException)

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -3,41 +3,18 @@ from os.path import basename
 from typing import List, Union
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from .. import models, schemas, worker
-from ..auth import CallContext, call_context
+from .. import models, schemas
 from ..aws.dynamodb import write_batches
 from ..crud import create_publish, get_publish_by_id, update_publish
+from ..database import get_db
 from ..settings import get_environment, get_settings
 
 LOG = logging.getLogger("exodus-gw")
 
-router = APIRouter()
-
-
-def get_db(request: Request):
-    return request.state.db
-
-
-@router.get("/healthcheck", tags=["service"])
-def healthcheck():
-    """Returns a successful response if the service is running."""
-    return {"detail": "exodus-gw is running"}
-
-
-@router.get("/healthcheck-worker", tags=["service"])
-def healthcheck_worker():
-    """Returns a successful response if background workers are running."""
-
-    msg = worker.ping.send()
-
-    # If we don't get a response in time, this will raise an exception and we'll
-    # respond with a 500 error, which seems reasonable.
-    result = msg.get_result(block=True, timeout=5000)
-
-    return {"detail": "background worker is running: ping => %s" % result}
+router = APIRouter(tags=["publish"])
 
 
 @router.post(
@@ -58,7 +35,6 @@ async def publish(env: str, db: Session = Depends(get_db)) -> models.Publish:
 @router.put(
     "/{env}/publish/{publish_id}",
     status_code=200,
-    tags=["publish"],
 )
 async def update_publish_items(
     env: str,
@@ -79,7 +55,6 @@ async def update_publish_items(
 @router.post(
     "/{env}/publish/{publish_id}/commit",
     status_code=200,
-    tags=["publish"],
 )
 async def commit_publish(
     env: str, publish_id: UUID, db: Session = Depends(get_db)
@@ -117,40 +92,3 @@ async def commit_publish(
             await write_batches(env, items + last_items, delete=True)
 
     return {}
-
-
-@router.get(
-    "/whoami",
-    response_model=CallContext,
-    tags=["service"],
-    responses={
-        200: {
-            "description": "returns caller's auth context",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "client": {
-                            "roles": ["someRole", "anotherRole"],
-                            "authenticated": True,
-                            "serviceAccountId": "clientappname",
-                        },
-                        "user": {
-                            "roles": ["viewer"],
-                            "authenticated": True,
-                            "internalUsername": "someuser",
-                        },
-                    }
-                }
-            },
-        }
-    },
-)
-def whoami(context: CallContext = Depends(call_context)):
-    """Return basic information on the caller's authentication & authorization context.
-
-    This endpoint may be used to determine whether the caller is authenticated to
-    the exodus-gw service, and if so, which set of role(s) are held by the caller.
-
-    It is a read-only endpoint intended for diagnosing authentication issues.
-    """
-    return context

--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -1,0 +1,65 @@
+import logging
+
+from fastapi import APIRouter, Depends
+
+from .. import worker
+from ..auth import CallContext, call_context
+
+LOG = logging.getLogger("exodus-gw")
+
+router = APIRouter(tags=["service"])
+
+
+@router.get("/healthcheck")
+def healthcheck():
+    """Returns a successful response if the service is running."""
+    return {"detail": "exodus-gw is running"}
+
+
+@router.get("/healthcheck-worker")
+def healthcheck_worker():
+    """Returns a successful response if background workers are running."""
+
+    msg = worker.ping.send()
+
+    # If we don't get a response in time, this will raise an exception and we'll
+    # respond with a 500 error, which seems reasonable.
+    result = msg.get_result(block=True, timeout=5000)
+
+    return {"detail": "background worker is running: ping => %s" % result}
+
+
+@router.get(
+    "/whoami",
+    response_model=CallContext,
+    responses={
+        200: {
+            "description": "returns caller's auth context",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "client": {
+                            "roles": ["someRole", "anotherRole"],
+                            "authenticated": True,
+                            "serviceAccountId": "clientappname",
+                        },
+                        "user": {
+                            "roles": ["viewer"],
+                            "authenticated": True,
+                            "internalUsername": "someuser",
+                        },
+                    }
+                }
+            },
+        }
+    },
+)
+def whoami(context: CallContext = Depends(call_context)):
+    """Return basic information on the caller's authentication & authorization context.
+
+    This endpoint may be used to determine whether the caller is authenticated to
+    the exodus-gw service, and if so, which set of role(s) are held by the caller.
+
+    It is a read-only endpoint intended for diagnosing authentication issues.
+    """
+    return context

--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -45,7 +45,7 @@ from ..settings import get_environment
 
 LOG = logging.getLogger("s3")
 
-router = APIRouter()
+router = APIRouter(tags=["upload"])
 
 
 # A partial TODO list for this API:
@@ -57,7 +57,6 @@ router = APIRouter()
 
 @router.post(
     "/upload/{env}/{key}",
-    tags=["upload"],
     summary="Create/complete multipart upload",
     response_class=Response,
 )
@@ -118,7 +117,6 @@ async def multipart_upload(
 
 @router.put(
     "/upload/{env}/{key}",
-    tags=["upload"],
     summary="Upload bytes",
     response_class=Response,
 )
@@ -237,7 +235,6 @@ async def multipart_put(
 
 @router.delete(
     "/upload/{env}/{key}",
-    tags=["upload"],
     summary="Abort multipart upload",
     response_description="Empty response",
     response_class=Response,

--- a/tests/app/test_db_session.py
+++ b/tests/app/test_db_session.py
@@ -4,10 +4,9 @@ from fastapi import Depends, HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from exodus_gw.database import SessionLocal
+from exodus_gw.database import SessionLocal, get_db
 from exodus_gw.main import app
 from exodus_gw.models import Publish
-from exodus_gw.routers.gateway import get_db
 
 # A hardcoded UUID so we can find what we've created.
 TEST_UUID = uuid.UUID("{12345678-1234-5678-1234-567812345678}")

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -2,21 +2,7 @@ import mock
 import pytest
 from fastapi import HTTPException
 
-from exodus_gw import models
-from exodus_gw.routers import gateway
-
-
-def test_healthcheck():
-    assert gateway.healthcheck() == {"detail": "exodus-gw is running"}
-
-
-def test_healthcheck_worker(stub_worker):
-    # This test exercises "real" dramatiq message handling via stub
-    # broker & worker, demonstrating that messages can be used from
-    # within tests.
-    assert gateway.healthcheck_worker() == {
-        "detail": "background worker is running: ping => pong"
-    }
+from exodus_gw import models, routers
 
 
 @pytest.mark.asyncio
@@ -29,7 +15,7 @@ def test_healthcheck_worker(stub_worker):
     ],
 )
 async def test_publish_env_exists(env, mock_db_session):
-    publish = await gateway.publish(env=env, db=mock_db_session)
+    publish = await routers.publish.publish(env=env, db=mock_db_session)
     assert isinstance(publish, models.Publish)
 
 
@@ -37,7 +23,7 @@ async def test_publish_env_exists(env, mock_db_session):
 async def test_publish_env_doesnt_exist(mock_db_session):
     env = "foo"
     with pytest.raises(HTTPException) as exc_info:
-        await gateway.publish(env=env, db=mock_db_session)
+        await routers.publish.publish(env=env, db=mock_db_session)
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Invalid environment='foo'"
 
@@ -59,7 +45,7 @@ async def test_update_publish_items_env_exists(
     items = mock_item_list[0] if env == "test3" else mock_item_list
 
     assert (
-        await gateway.update_publish_items(
+        await routers.publish.update_publish_items(
             env=env,
             publish_id=publish_id,
             items=items,
@@ -77,7 +63,7 @@ async def test_update_publish_items_env_doesnt_exist(
     publish_id = "123e4567-e89b-12d3-a456-426614174000"
 
     with pytest.raises(HTTPException) as exc_info:
-        await gateway.update_publish_items(
+        await routers.publish.update_publish_items(
             env=env,
             publish_id=publish_id,
             items=mock_item_list,
@@ -97,8 +83,8 @@ async def test_update_publish_items_env_doesnt_exist(
         "test3",
     ],
 )
-@mock.patch("exodus_gw.routers.gateway.write_batches")
-@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+@mock.patch("exodus_gw.routers.publish.write_batches")
+@mock.patch("exodus_gw.routers.publish.get_publish_by_id")
 async def test_commit_publish(
     mock_get_publish,
     mock_write_batches,
@@ -110,7 +96,7 @@ async def test_commit_publish(
     mock_write_batches.return_value = True
 
     assert (
-        await gateway.commit_publish(
+        await routers.publish.commit_publish(
             env=env, publish_id=mock_publish.id, db=mock_db_session
         )
         == {}
@@ -126,12 +112,12 @@ async def test_commit_publish(
 
 
 @pytest.mark.asyncio
-@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+@mock.patch("exodus_gw.routers.publish.get_publish_by_id")
 async def test_commit_publish_env_doesnt_exist(mock_publish, mock_db_session):
     env = "foo"
 
     with pytest.raises(HTTPException) as exc_info:
-        await gateway.commit_publish(
+        await routers.publish.commit_publish(
             env=env, publish_id=mock_publish.id, db=mock_db_session
         )
 
@@ -140,15 +126,15 @@ async def test_commit_publish_env_doesnt_exist(mock_publish, mock_db_session):
 
 
 @pytest.mark.asyncio
-@mock.patch("exodus_gw.routers.gateway.write_batches")
-@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+@mock.patch("exodus_gw.routers.publish.write_batches")
+@mock.patch("exodus_gw.routers.publish.get_publish_by_id")
 async def test_commit_publish_write_failed(
     mock_get_publish, mock_write_batches, mock_publish, mock_db_session
 ):
     mock_get_publish.return_value = mock_publish
     mock_write_batches.side_effect = [False, True]
 
-    await gateway.commit_publish(
+    await routers.publish.commit_publish(
         env="test", publish_id=mock_publish.id, db=mock_db_session
     )
 
@@ -162,15 +148,15 @@ async def test_commit_publish_write_failed(
 
 
 @pytest.mark.asyncio
-@mock.patch("exodus_gw.routers.gateway.write_batches")
-@mock.patch("exodus_gw.routers.gateway.get_publish_by_id")
+@mock.patch("exodus_gw.routers.publish.write_batches")
+@mock.patch("exodus_gw.routers.publish.get_publish_by_id")
 async def test_commit_publish_entry_point_files_failed(
     mock_get_publish, mock_write_batches, mock_publish, mock_db_session
 ):
     mock_get_publish.return_value = mock_publish
     mock_write_batches.side_effect = [True, False, True]
 
-    await gateway.commit_publish(
+    await routers.publish.commit_publish(
         env="test", publish_id=mock_publish.id, db=mock_db_session
     )
 
@@ -182,10 +168,3 @@ async def test_commit_publish_entry_point_files_failed(
         ],
         any_order=False,
     )
-
-
-def test_whoami():
-    # All work is done by fastapi deserialization, so this doesn't actually
-    # do anything except return the passed object.
-    context = object()
-    assert gateway.whoami(context=context) is context

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -1,0 +1,26 @@
+import mock
+import pytest
+from fastapi import HTTPException
+
+from exodus_gw import models
+from exodus_gw.routers import service
+
+
+def test_healthcheck():
+    assert service.healthcheck() == {"detail": "exodus-gw is running"}
+
+
+def test_healthcheck_worker(stub_worker):
+    # This test exercises "real" dramatiq message handling via stub
+    # broker & worker, demonstrating that messages can be used from
+    # within tests.
+    assert service.healthcheck_worker() == {
+        "detail": "background worker is running: ping => pong"
+    }
+
+
+def test_whoami():
+    # All work is done by fastapi deserialization, so this doesn't actually
+    # do anything except return the passed object.
+    context = object()
+    assert service.whoami(context=context) is context

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import HTTPException
 
 from exodus_gw.aws.util import xml_response
-from exodus_gw.routers.s3 import abort_multipart_upload, multipart_upload
+from exodus_gw.routers.upload import abort_multipart_upload, multipart_upload
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 from fastapi import HTTPException
 
-from exodus_gw.routers.s3 import upload
+from exodus_gw.routers.upload import upload
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 


### PR DESCRIPTION
This commit moves various endpoints into more appropriate python
modules. It is a refactor only, with no functional impact.

The initial motivation was to ensure the publish APIs and service
APIs don't live in the same module. These endpoints are quite
unrelated and it doesn't make sense to me that their implementation,
and associated tests, were all dumped into the same 'gateway'
module.

Going a bit further, it seems reasonable to have the python modules
matching the OpenAPI tags used for the endpoints. Both the tagging
and the split between modules are ways of grouping related
functionality and there's no reason to have one grouping in the
source code layout and a different grouping in the API spec, so let's
rename the modules to make them match. This also allows applying
default tags in the APIRouter of each module, so you can't forget
to apply them when adding new endpoints.