### PR TITLE
Add links to Publish objects [RHELDST-4706]

### DIFF
--- a/examples/exodus-sync
+++ b/examples/exodus-sync
@@ -110,15 +110,6 @@ def publish_items(args, items):
 
     print("Created publish {}".format(publish))
 
-    # TODO: we shouldn't have to assemble these URLs themselves, the object
-    # should have come with 'links' already - RHELDST-4706.
-    publish["links"] = {
-        "self": "/{env}/publish/{id}".format(env=args.env, id=publish["id"]),
-        "commit": "/{env}/publish/{id}/commit".format(
-            env=args.env, id=publish["id"]
-        ),
-    }
-
     put_url = urljoin(args.exodus_gw_url, publish["links"]["self"])
     for item in items:
         r = session.put(

--- a/exodus_gw/crud.py
+++ b/exodus_gw/crud.py
@@ -1,4 +1,5 @@
 from typing import List, Union
+from uuid import uuid4
 
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, Session, lazyload
@@ -6,8 +7,8 @@ from sqlalchemy.orm import Query, Session, lazyload
 from . import models, schemas
 
 
-def create_publish(db: Session) -> models.Publish:
-    db_publish = models.Publish()
+def create_publish(env: str, db: Session) -> models.Publish:
+    db_publish = models.Publish(id=uuid4(), env=env)
     db.add(db_publish)
     db.commit()
     db.refresh(db_publish)

--- a/exodus_gw/models.py
+++ b/exodus_gw/models.py
@@ -19,6 +19,7 @@ class Publish(Base):
         unique=True,
         nullable=False,
     )
+    env = Column(String, nullable=False)
     items = relationship("Item", back_populates="publish")
 
 

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -93,7 +93,7 @@ async def publish(
     # Validate environment from caller.
     get_environment(env)
 
-    return create_publish(db)
+    return create_publish(env, db)
 
 
 @router.put(

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -1,8 +1,9 @@
+from os.path import join
 from typing import List
 from uuid import UUID
 
 from fastapi import Path
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, root_validator
 
 PathEnv = Path(
     ...,
@@ -47,10 +48,23 @@ class PublishBase(BaseModel):
 
 
 class Publish(PublishBase):
+    env: str = Field(
+        ..., description="""Environment to which this publish belongs."""
+    )
+    links: dict = Field(
+        {}, description="""URL links related to this publish."""
+    )
     items: List[Item] = Field(
         [],
         description="""All items (pieces of content) included in this publish.""",
     )
+
+    @root_validator
+    @classmethod
+    def make_links(cls, values):
+        _self = join("/", values["env"], "publish", str(values["id"]))
+        values["links"] = {"self": _self, "commit": join(_self, "commit")}
+        return values
 
     class Config:
         orm_mode = True

--- a/tests/app/test_db_session.py
+++ b/tests/app/test_db_session.py
@@ -16,7 +16,7 @@ TEST_UUID = uuid.UUID("{12345678-1234-5678-1234-567812345678}")
 # rollback or raise based on params
 @app.post("/test_db_session/make_publish")
 def make_publish(mode: str = None, db: Session = Depends(get_db)):
-    p = Publish(id=TEST_UUID)
+    p = Publish(id=TEST_UUID, env="test")
     db.add(p)
 
     if mode == "rollback":

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 from fastapi import HTTPException
 
-from exodus_gw import models, routers
+from exodus_gw import models, routers, schemas
 
 
 @pytest.mark.asyncio
@@ -29,6 +29,18 @@ async def test_publish_env_doesnt_exist(mock_db_session):
 
 
 @pytest.mark.asyncio
+async def test_publish_links(mock_db_session):
+    publish = await routers.publish.publish(env="test", db=mock_db_session)
+
+    # The schema (realistic result) resulting from the publish
+    # should contain accurate links.
+    assert schemas.Publish(**publish.__dict__).links == {
+        "self": "/test/publish/%s" % publish.id,
+        "commit": "/test/publish/%s/commit" % publish.id,
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "env",
     [
@@ -41,7 +53,7 @@ async def test_update_publish_items_env_exists(
     env, mock_db_session, mock_item_list
 ):
     publish_id = "123e4567-e89b-12d3-a456-426614174000"
-    # Simulate single item to "test3" environment to test list coersion.
+    # Simulate single item to "test3" environment to test list coercion.
     items = mock_item_list[0] if env == "test3" else mock_item_list
 
     assert (


### PR DESCRIPTION
This commit introduces the "links" attribute on Publish schema objects.
These links are URLs related to the object, served automatically by the
schema so callers needn't know how to construct the URLs themselves.