### PR TITLE
Fix duplicate tag on 'head object' endpoint

### DIFF
--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -300,7 +300,6 @@ async def abort_multipart_upload(
 
 @router.head(
     "/upload/{env}/{key}",
-    tags=["upload"],
     summary="Request head object",
     response_class=Response,
 )


### PR DESCRIPTION
We don't need to set tags on individual endpoints any more,
as we've set a module-wide tag. In practice, adding the tag
in both places seems to cause the API to be listed twice
in docs.