### PR TITLE
Extend docs for schemas and parameters

### DIFF
--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -38,6 +38,27 @@ for information on how to integrate an authentication mechanism.
 
 If you are a client looking to make use of exodus-gw, consult your organization's
 internal documentation for advice on how to authenticate with exodus-gw.
+
+
+## Environments
+
+Many APIs in exodus-gw use the concept of an "environment" to control the target system
+of an operation.
+
+The set of environments is configured when exodus-gw is deployed. For example, separate
+"production" and "staging" environments may be configured, making use of separate storage
+backends.
+
+Different environments will also require the user to hold different roles. For example,
+a client might be permitted only to write to one of the configured environments, or all
+of them, depending on the configuration of the server.
+
+If you are deploying an instance of exodus-gw, see
+[the deployment guide](https://release-engineering.github.io/exodus-gw/deployment.html)
+for information on how to configure environments.
+
+If you are a client looking to make use of exodus-gw, consult your organization's
+internal documentation for advice on which environment(s) you should be using.
 """
 
 import logging.config

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -85,7 +85,9 @@ router = APIRouter(tags=[openapi_tag["name"]])
     response_model=schemas.Publish,
     status_code=200,
 )
-async def publish(env: str, db: Session = Depends(get_db)) -> models.Publish:
+async def publish(
+    env: str = schemas.PathEnv, db: Session = Depends(get_db)
+) -> models.Publish:
     """Creates and returns a new publish object."""
 
     # Validate environment from caller.
@@ -99,9 +101,9 @@ async def publish(env: str, db: Session = Depends(get_db)) -> models.Publish:
     status_code=200,
 )
 async def update_publish_items(
-    env: str,
-    publish_id: UUID,
     items: Union[schemas.ItemBase or List[schemas.ItemBase]],
+    publish_id: UUID = schemas.PathPublishId,
+    env: str = schemas.PathEnv,
     db: Session = Depends(get_db),
 ) -> dict:
     """Add publish items to an existing publish object.
@@ -128,7 +130,9 @@ async def update_publish_items(
     status_code=200,
 )
 async def commit_publish(
-    env: str, publish_id: UUID, db: Session = Depends(get_db)
+    publish_id: UUID = schemas.PathPublishId,
+    env: str = schemas.PathEnv,
+    db: Session = Depends(get_db),
 ) -> dict:
     """Commit an existing publish object.
 

--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -67,6 +67,7 @@ from typing import Optional
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
 
+from .. import schemas
 from ..aws.client import S3ClientWrapper as s3_client
 from ..aws.util import (
     RequestReader,
@@ -97,7 +98,7 @@ router = APIRouter(tags=[openapi_tag["name"]])
 )
 async def multipart_upload(
     request: Request,
-    env: str = Path(..., description="Target CDN environment"),
+    env: str = schemas.PathEnv,
     key: str = Path(..., description="S3 object key"),
     uploadId: Optional[str] = Query(
         None,
@@ -157,7 +158,7 @@ async def multipart_upload(
 )
 async def upload(
     request: Request,
-    env: str = Path(..., description="Target CDN environment"),
+    env: str = schemas.PathEnv,
     key: str = Path(..., description="S3 object key"),
     uploadId: Optional[str] = Query(
         None, description="ID of an existing multi-part upload."
@@ -275,7 +276,7 @@ async def multipart_put(
     response_class=Response,
 )
 async def abort_multipart_upload(
-    env: str = Path(..., description="Target CDN environment"),
+    env: str = schemas.PathEnv,
     key: str = Path(..., description="S3 object key"),
     uploadId: str = Query(..., description="ID of a multipart upload"),
 ):
@@ -305,7 +306,7 @@ async def abort_multipart_upload(
     response_class=Response,
 )
 async def head(
-    env: str = Path(..., description="Target CDN environment"),
+    env: str = schemas.PathEnv,
     key: str = Path(..., description="S3 object key"),
 ):
     """Retrieve metadata from an S3 object."""

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -1,28 +1,56 @@
 from typing import List
 from uuid import UUID
 
-from pydantic import BaseModel
+from fastapi import Path
+from pydantic import BaseModel, Field
+
+PathEnv = Path(
+    ...,
+    title="environment",
+    description="[Environment](#section/Environments) on which to operate.",
+)
+
+PathPublishId = Path(
+    ...,
+    title="publish ID",
+    description="UUID of an existing publish object.",
+)
 
 
 class ItemBase(BaseModel):
-    web_uri: str
-    object_key: str
+    web_uri: str = Field(
+        ...,
+        description="URI, relative to CDN root, which shall be used to expose this object.",
+    )
+    object_key: str = Field(
+        ...,
+        description=(
+            "Key of blob to be exposed; should be the SHA256 checksum of a previously uploaded "
+            "piece of content, in lowercase hex-digest form."
+        ),
+    )
+
     from_date: str
 
 
 class Item(ItemBase):
-    publish_id: UUID
+    publish_id: UUID = Field(
+        ..., description="Unique ID of publish object containing this item."
+    )
 
     class Config:
         orm_mode = True
 
 
 class PublishBase(BaseModel):
-    id: UUID
+    id: UUID = Field(..., description="Unique ID of publish object.")
 
 
 class Publish(PublishBase):
-    items: List[Item] = []
+    items: List[Item] = Field(
+        [],
+        description="""All items (pieces of content) included in this publish.""",
+    )
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
We should try to have at least some brief doc strings for most
inputs and outputs explaining what they are. This can be done
by using Path or Field objects when defining them.

A couple of Path objects were added to schemas so they can be
shared across APIs without explicitly duplicating the docs for
each API.