### PR TITLE
Commit publishes in background process [RHELDST-4798]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -115,3 +115,6 @@ disable=print-statement,
         # both pytest fixtures and fastapi Depends will result in unused
         # arguments as part of normal usage
         unused-argument,
+        # we need to import dramatiq actors to the worker after broker
+        # is set
+        wrong-import-position,

--- a/exodus_gw/aws/client.py
+++ b/exodus_gw/aws/client.py
@@ -1,6 +1,7 @@
 import os
 
 import aioboto3
+import boto3.session
 from botocore.config import Config
 
 
@@ -88,12 +89,12 @@ class DynamoDBClientWrapper:
 
     def __init__(self, profile: str):
         """Prepare a client for the given profile. This object must be used
-        via 'async with' in order to obtain access to the client.
+        via 'with' in order to obtain access to the client.
 
         Note: Session creation will fail if provided profile cannot be found.
         """
 
-        session = aioboto3.Session(profile_name=profile)
+        session = boto3.session.Session(profile_name=profile)
 
         self._client_context = session.client(
             "dynamodb",
@@ -101,8 +102,8 @@ class DynamoDBClientWrapper:
             or None,
         )
 
-    async def __aenter__(self):
-        return await self._client_context.__aenter__()
+    def __enter__(self):
+        return self._client_context
 
-    async def __aexit__(self, exc_type, exc, tb):
-        await self._client_context.__aexit__(exc_type, exc, tb)
+    def __exit__(self, exc_type, exc, tb):
+        return

--- a/exodus_gw/worker/__init__.py
+++ b/exodus_gw/worker/__init__.py
@@ -4,6 +4,8 @@ from .broker import new_broker
 
 dramatiq.set_broker(new_broker())
 
+from .publish import commit  # noqa
+
 
 @dramatiq.actor(store_results=True, priority=100)
 def ping():

--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -1,0 +1,41 @@
+from os.path import basename
+
+import dramatiq
+from sqlalchemy.orm import Session
+
+from exodus_gw.aws.dynamodb import write_batches
+from exodus_gw.crud import get_publish_by_id
+from exodus_gw.database import db_engine
+from exodus_gw.settings import Settings
+
+
+@dramatiq.actor
+def commit(publish_id: str, env: str):
+    settings = Settings()
+    db = Session(bind=db_engine(settings))
+
+    items = []
+    last_items = []
+
+    for item in get_publish_by_id(db, publish_id).items:
+        if basename(item.web_uri) in settings.entry_point_files:
+            last_items.append(item)
+        else:
+            items.append(item)
+
+    items_written = False
+    last_items_written = False
+
+    if items:
+        items_written = write_batches(env, items)
+
+    if not items_written:
+        # Delete all items if failed to write any items.
+        write_batches(env, items, delete=True)
+    elif last_items:
+        # Write any last_items if successfully wrote all items.
+        last_items_written = write_batches(env, last_items)
+
+        if not last_items_written:
+            # Delete everything if failed to write last_items.
+            write_batches(env, items + last_items, delete=True)

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -6,7 +6,6 @@ import pytest
 from exodus_gw.aws import dynamodb
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "delete,expected_request",
     [
@@ -81,52 +80,46 @@ from exodus_gw.aws import dynamodb
     ],
     ids=["Put", "Delete"],
 )
-async def test_batch_write(
-    mock_aws_client, mock_publish, delete, expected_request
+def test_batch_write(
+    mock_boto3_client, mock_publish, delete, expected_request
 ):
     request = dynamodb.create_request("test", mock_publish.items, delete)
 
     # Represent successful write/delete of all items to the table.
-    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
-    await dynamodb.batch_write("test", request)
+    mock_boto3_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+    dynamodb.batch_write("test", request)
 
     # Should've requested write of all items.
-    mock_aws_client.batch_write_item.assert_called_once_with(
+    mock_boto3_client.batch_write_item.assert_called_once_with(
         RequestItems=expected_request
     )
 
 
-@pytest.mark.asyncio
-async def test_batch_write_item_limit(mock_aws_client, mock_publish, caplog):
+def test_batch_write_item_limit(mock_boto3_client, mock_publish, caplog):
     items = mock_publish.items * 9
     request = dynamodb.create_request("test", items)
 
     with pytest.raises(ValueError) as exc_info:
-        await dynamodb.batch_write("test", request)
+        dynamodb.batch_write("test", request)
 
     assert "Cannot process more than 25 items per request" in caplog.text
     assert str(exc_info.value) == "Request contains too many items (27)"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("delete", [False, True], ids=["Put", "Delete"])
-async def test_write_batches(delete, mock_aws_client, mock_publish, caplog):
+def test_write_batches(delete, mock_boto3_client, mock_publish, caplog):
     caplog.set_level(logging.INFO, logger="exodus-gw")
-    mock_aws_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+    mock_boto3_client.batch_write_item.return_value = {"UnprocessedItems": {}}
 
     expected_msg = "Items successfully %s" % "deleted" if delete else "written"
 
-    assert (
-        await dynamodb.write_batches("test", mock_publish.items, delete)
-        is True
-    )
+    assert dynamodb.write_batches("test", mock_publish.items, delete) is True
 
     assert expected_msg in caplog.text
 
 
-@pytest.mark.asyncio
 @mock.patch("exodus_gw.aws.dynamodb.batch_write")
-async def test_write_batches_put_fail(mock_batch_write, mock_publish, caplog):
+def test_write_batches_put_fail(mock_batch_write, mock_publish, caplog):
     caplog.set_level(logging.INFO, logger="exodus-gw")
     mock_batch_write.return_value = {
         "UnprocessedItems": {
@@ -136,16 +129,13 @@ async def test_write_batches_put_fail(mock_batch_write, mock_publish, caplog):
         }
     }
 
-    assert await dynamodb.write_batches("test", mock_publish.items) is False
+    assert dynamodb.write_batches("test", mock_publish.items) is False
 
     assert "One or more writes were unsuccessful" in caplog.text
 
 
-@pytest.mark.asyncio
 @mock.patch("exodus_gw.aws.dynamodb.batch_write")
-async def test_write_batches_delete_fail(
-    mock_batch_write, mock_publish, caplog
-):
+def test_write_batches_delete_fail(mock_batch_write, mock_publish, caplog):
     mock_batch_write.return_value = {
         "UnprocessedItems": {
             "my-table": [
@@ -155,7 +145,7 @@ async def test_write_batches_delete_fail(
     }
 
     with pytest.raises(RuntimeError) as exc_info:
-        await dynamodb.write_batches("test", mock_publish.items, delete=True)
+        dynamodb.write_batches("test", mock_publish.items, delete=True)
 
     assert (
         "Unprocessed items:\n\t%s"
@@ -171,16 +161,13 @@ async def test_write_batches_delete_fail(
     assert "Deletion failed" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("delete", [False, True], ids=["Put", "Delete"])
-async def test_write_batches_excs(
-    mock_aws_client, mock_publish, delete, caplog
-):
-    mock_aws_client.batch_write_item.side_effect = ValueError()
+def test_write_batches_excs(mock_boto3_client, mock_publish, delete, caplog):
+    mock_boto3_client.batch_write_item.side_effect = ValueError()
 
     expected_msg = "Exception while %s" % "deleting" if delete else "writing"
 
     with pytest.raises(ValueError):
-        await dynamodb.write_batches("test", mock_publish.items, delete)
+        dynamodb.write_batches("test", mock_publish.items, delete)
 
     assert expected_msg in caplog.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 import dramatiq
 import mock
 import pytest
-from mock import MagicMock
 from sqlalchemy.orm.session import Session
 
 # This must happen early during tests, prior to import of
@@ -24,6 +23,15 @@ def mock_aws_client():
         yield aws_client
 
 
+@pytest.fixture(autouse=True)
+def mock_boto3_client():
+    with mock.patch("boto3.session.Session") as mock_session:
+        client = mock.MagicMock()
+        client.__enter__.return_value = client
+        mock_session().client.return_value = client
+        yield client
+
+
 @pytest.fixture()
 def mock_request_reader():
     # We don't use the real request reader for these tests as it becomes
@@ -36,8 +44,8 @@ def mock_request_reader():
 @pytest.fixture()
 def mock_db_session():
     db_session = Session()
-    db_session.add = MagicMock()
-    db_session.refresh = MagicMock()
+    db_session.add = mock.MagicMock()
+    db_session.refresh = mock.MagicMock()
     yield db_session
 
 

--- a/tests/worker/test_actors.py
+++ b/tests/worker/test_actors.py
@@ -1,0 +1,114 @@
+import mock
+import pytest
+from fastapi import HTTPException
+
+from exodus_gw import worker
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        "test",
+        "test2",
+        "test3",
+    ],
+)
+@mock.patch("exodus_gw.worker.publish.Session")
+@mock.patch("exodus_gw.worker.publish.write_batches")
+@mock.patch("exodus_gw.worker.publish.get_publish_by_id")
+def test_commit_publish(
+    mock_get_publish,
+    mock_write_batches,
+    mock_alch_session,
+    env,
+    mock_publish,
+    mock_db_session,
+):
+    mock_get_publish.return_value = mock_publish
+    mock_write_batches.return_value = True
+    mock_alch_session.return_value = mock_db_session
+
+    worker.publish.commit(
+        env=env,
+        publish_id=mock_publish.id,
+    )
+
+    # Should write repomd.xml file separately after other items.
+    mock_write_batches.assert_has_calls(
+        calls=[
+            mock.call(env, mock_publish.items[:2]),
+            mock.call(env, [mock_publish.items[2]]),
+        ],
+        any_order=False,
+    )
+
+
+@mock.patch("exodus_gw.worker.publish.get_publish_by_id")
+def test_commit_publish_env_doesnt_exist(mock_publish):
+    env = "foo"
+
+    with pytest.raises(HTTPException) as exc_info:
+        worker.publish.commit(
+            env=env,
+            publish_id=mock_publish.id,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Invalid environment='foo'"
+
+
+@mock.patch("exodus_gw.worker.publish.Session")
+@mock.patch("exodus_gw.worker.publish.write_batches")
+@mock.patch("exodus_gw.worker.publish.get_publish_by_id")
+def test_commit_publish_write_failed(
+    mock_get_publish,
+    mock_write_batches,
+    mock_alch_session,
+    mock_publish,
+    mock_db_session,
+):
+    mock_get_publish.return_value = mock_publish
+    mock_write_batches.side_effect = [False, True]
+    mock_alch_session.return_value = mock_db_session
+
+    worker.publish.commit(
+        env="test",
+        publish_id=mock_publish.id,
+    )
+
+    mock_write_batches.assert_has_calls(
+        calls=[
+            mock.call("test", mock_publish.items[:2]),
+            mock.call("test", mock_publish.items[:2], delete=True),
+        ],
+        any_order=False,
+    )
+
+
+@mock.patch("exodus_gw.worker.publish.Session")
+@mock.patch("exodus_gw.worker.publish.write_batches")
+@mock.patch("exodus_gw.worker.publish.get_publish_by_id")
+def test_commit_publish_entry_point_files_failed(
+    mock_get_publish,
+    mock_write_batches,
+    mock_alch_session,
+    mock_publish,
+    mock_db_session,
+):
+    mock_get_publish.return_value = mock_publish
+    mock_write_batches.side_effect = [True, False, True]
+    mock_alch_session.return_value = mock_db_session
+
+    worker.publish.commit(
+        env="test",
+        publish_id=mock_publish.id,
+    )
+
+    mock_write_batches.assert_has_calls(
+        calls=[
+            mock.call("test", mock_publish.items[:2]),
+            mock.call("test", [mock_publish.items[2]]),
+            mock.call("test", mock_publish.items, delete=True),
+        ],
+        any_order=False,
+    )


### PR DESCRIPTION
This commit moves the writing of items to DynamoDB to the previously
established dramatiq background worker.

As asyncio operations are incompatible with the new task delegation
method, async/await functionality was removed from the commit_publish
endpoint and the dynamodb functions and client.