### PR TITLE
Refactor lifecycle of dependencies, reduce usage of globals

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -107,4 +107,6 @@ disable=print-statement,
         bad-continuation,
         line-too-long,
         invalid-name,
-
+        # both pytest fixtures and fastapi Depends will result in unused
+        # arguments as part of normal usage
+        unused-argument,

--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -5,8 +5,6 @@ from typing import List, Optional, Set
 from fastapi import Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from .settings import Settings, get_settings
-
 LOG = logging.getLogger("exodus-gw")
 
 
@@ -38,11 +36,10 @@ class CallContext(BaseModel):
     user: UserContext = UserContext()
 
 
-def call_context(
-    request: Request, settings: Settings = Depends(get_settings)
-) -> CallContext:
+def call_context(request: Request) -> CallContext:
     """Returns the CallContext for the current request."""
 
+    settings = request.app.state.settings
     header = settings.call_context_header
     header_value = request.headers.get(header)
     if not header_value:

--- a/exodus_gw/crud.py
+++ b/exodus_gw/crud.py
@@ -5,10 +5,11 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, Session, lazyload
 
 from . import models, schemas
+from .settings import Environment
 
 
-def create_publish(env: str, db: Session) -> models.Publish:
-    db_publish = models.Publish(id=uuid4(), env=env)
+def create_publish(env: Environment, db: Session) -> models.Publish:
+    db_publish = models.Publish(id=uuid4(), env=env.name)
     db.add(db_publish)
     db.commit()
     db.refresh(db_publish)

--- a/exodus_gw/database.py
+++ b/exodus_gw/database.py
@@ -1,4 +1,3 @@
-from fastapi import Request
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -15,8 +14,3 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
-
-
-def get_db(request: Request):
-    """DB session accessor for use with FastAPI's dependency injection system."""
-    return request.state.db

--- a/exodus_gw/database.py
+++ b/exodus_gw/database.py
@@ -2,13 +2,17 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-from .settings import get_settings
+from .settings import Settings
+
+# FIXME: DB engine should not be initialized at import time,
+# it should be initialized after app start and use the existing
+# settings object.
 
 # The database name is identical to the user name
 SQLALCHEMY_DATABASE_URL = (
     "postgresql://{s.db_service_user}:{s.db_service_pass}@"
     "{s.db_service_host}:{s.db_service_port}/{s.db_service_user}"
-).format(s=get_settings())
+).format(s=Settings())
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/exodus_gw/database.py
+++ b/exodus_gw/database.py
@@ -1,20 +1,20 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 
 from .settings import Settings
 
-# FIXME: DB engine should not be initialized at import time,
-# it should be initialized after app start and use the existing
-# settings object.
-
-# The database name is identical to the user name
-SQLALCHEMY_DATABASE_URL = (
-    "postgresql://{s.db_service_user}:{s.db_service_pass}@"
-    "{s.db_service_host}:{s.db_service_port}/{s.db_service_user}"
-).format(s=Settings())
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
-
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
 Base = declarative_base()
+
+
+def db_url(settings: Settings):
+    if settings.db_url:
+        return settings.db_url
+
+    return (
+        "postgresql://{s.db_service_user}:{s.db_service_pass}@"
+        "{s.db_service_host}:{s.db_service_port}/{s.db_service_user}"
+    ).format(s=settings)
+
+
+def db_engine(settings: Settings):
+    return create_engine(db_url(settings))

--- a/exodus_gw/deps.py
+++ b/exodus_gw/deps.py
@@ -1,13 +1,24 @@
 """Functions intended for use with fastapi.Depends."""
 
-from fastapi import Depends, Request
+from fastapi import Depends, Path, Request
 
 from .auth import call_context
+from .settings import get_environment
 
 
 def get_db(request: Request):
     """DB session accessor for use with FastAPI's dependency injection system."""
     return request.state.db
+
+
+def get_environment_from_path(
+    env: str = Path(
+        ...,
+        title="environment",
+        description="[Environment](#section/Environments) on which to operate.",
+    )  # pylint: disable=redefined-outer-name
+):
+    return get_environment(env)
 
 
 # These are the preferred objects for use in endpoints,
@@ -17,3 +28,4 @@ def get_db(request: Request):
 #
 db = Depends(get_db)
 call_context = Depends(call_context)
+env = Depends(get_environment_from_path)

--- a/exodus_gw/deps.py
+++ b/exodus_gw/deps.py
@@ -3,7 +3,7 @@
 from fastapi import Depends, Path, Request
 
 from .auth import call_context
-from .settings import get_environment
+from .settings import Settings, get_environment
 
 
 def get_db(request: Request):
@@ -11,14 +11,19 @@ def get_db(request: Request):
     return request.state.db
 
 
+def get_settings(request: Request):
+    return request.app.state.settings
+
+
 def get_environment_from_path(
     env: str = Path(
         ...,
         title="environment",
         description="[Environment](#section/Environments) on which to operate.",
-    )  # pylint: disable=redefined-outer-name
+    ),  # pylint: disable=redefined-outer-name
+    settings: Settings = Depends(get_settings),
 ):
-    return get_environment(env)
+    return get_environment(env, settings)
 
 
 # These are the preferred objects for use in endpoints,
@@ -29,3 +34,4 @@ def get_environment_from_path(
 db = Depends(get_db)
 call_context = Depends(call_context)
 env = Depends(get_environment_from_path)
+settings = Depends(get_settings)

--- a/exodus_gw/deps.py
+++ b/exodus_gw/deps.py
@@ -1,0 +1,19 @@
+"""Functions intended for use with fastapi.Depends."""
+
+from fastapi import Depends, Request
+
+from .auth import call_context
+
+
+def get_db(request: Request):
+    """DB session accessor for use with FastAPI's dependency injection system."""
+    return request.state.db
+
+
+# These are the preferred objects for use in endpoints,
+# e.g.
+#
+#   db: Session = deps.db
+#
+db = Depends(get_db)
+call_context = Depends(call_context)

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -69,7 +69,7 @@ from sqlalchemy.orm import Session
 from .. import deps, models, schemas
 from ..aws.dynamodb import write_batches
 from ..crud import create_publish, get_publish_by_id, update_publish
-from ..settings import get_environment, get_settings
+from ..settings import Environment, get_settings
 
 LOG = logging.getLogger("exodus-gw")
 
@@ -85,12 +85,9 @@ router = APIRouter(tags=[openapi_tag["name"]])
     status_code=200,
 )
 async def publish(
-    env: str = schemas.PathEnv, db: Session = deps.db
+    env: Environment = deps.env, db: Session = deps.db
 ) -> models.Publish:
     """Creates and returns a new publish object."""
-
-    # Validate environment from caller.
-    get_environment(env)
 
     return create_publish(env, db)
 
@@ -102,7 +99,7 @@ async def publish(
 async def update_publish_items(
     items: Union[schemas.ItemBase or List[schemas.ItemBase]],
     publish_id: UUID = schemas.PathPublishId,
-    env: str = schemas.PathEnv,
+    env: Environment = deps.env,
     db: Session = deps.db,
 ) -> dict:
     """Add publish items to an existing publish object.
@@ -116,9 +113,6 @@ async def update_publish_items(
     Items cannot be added to a publish once it has been committed.
     """
 
-    # Validate environment from caller.
-    get_environment(env)
-
     update_publish(db, items, publish_id)
 
     return {}
@@ -130,7 +124,7 @@ async def update_publish_items(
 )
 async def commit_publish(
     publish_id: UUID = schemas.PathPublishId,
-    env: str = schemas.PathEnv,
+    env: Environment = deps.env,
     db: Session = deps.db,
 ) -> dict:
     """Commit an existing publish object.
@@ -150,9 +144,6 @@ async def commit_publish(
     path are being committed concurrently, URIs on the CDN may end up pointing to
     objects from any of those publishes.
     """
-
-    # Validate environment from caller.
-    get_environment(env)
 
     settings = get_settings()
 

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -69,7 +69,7 @@ from sqlalchemy.orm import Session
 from .. import deps, models, schemas
 from ..aws.dynamodb import write_batches
 from ..crud import create_publish, get_publish_by_id, update_publish
-from ..settings import Environment, get_settings
+from ..settings import Environment, Settings
 
 LOG = logging.getLogger("exodus-gw")
 
@@ -126,6 +126,7 @@ async def commit_publish(
     publish_id: UUID = schemas.PathPublishId,
     env: Environment = deps.env,
     db: Session = deps.db,
+    settings: Settings = deps.settings,
 ) -> dict:
     """Commit an existing publish object.
 
@@ -144,8 +145,6 @@ async def commit_publish(
     path are being committed concurrently, URIs on the CDN may end up pointing to
     objects from any of those publishes.
     """
-
-    settings = get_settings()
 
     items = []
     items_written = False

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -63,13 +63,12 @@ from os.path import basename
 from typing import List, Union
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from sqlalchemy.orm import Session
 
-from .. import models, schemas
+from .. import deps, models, schemas
 from ..aws.dynamodb import write_batches
 from ..crud import create_publish, get_publish_by_id, update_publish
-from ..database import get_db
 from ..settings import get_environment, get_settings
 
 LOG = logging.getLogger("exodus-gw")
@@ -86,7 +85,7 @@ router = APIRouter(tags=[openapi_tag["name"]])
     status_code=200,
 )
 async def publish(
-    env: str = schemas.PathEnv, db: Session = Depends(get_db)
+    env: str = schemas.PathEnv, db: Session = deps.db
 ) -> models.Publish:
     """Creates and returns a new publish object."""
 
@@ -104,7 +103,7 @@ async def update_publish_items(
     items: Union[schemas.ItemBase or List[schemas.ItemBase]],
     publish_id: UUID = schemas.PathPublishId,
     env: str = schemas.PathEnv,
-    db: Session = Depends(get_db),
+    db: Session = deps.db,
 ) -> dict:
     """Add publish items to an existing publish object.
 
@@ -132,7 +131,7 @@ async def update_publish_items(
 async def commit_publish(
     publish_id: UUID = schemas.PathPublishId,
     env: str = schemas.PathEnv,
-    db: Session = Depends(get_db),
+    db: Session = deps.db,
 ) -> dict:
     """Commit an existing publish object.
 

--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -2,12 +2,11 @@
 
 import logging
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from sqlalchemy.orm import Session
 
-from .. import worker
-from ..auth import CallContext, call_context
-from ..database import get_db
+from .. import deps, worker
+from ..auth import CallContext
 
 LOG = logging.getLogger("exodus-gw")
 
@@ -23,7 +22,7 @@ def healthcheck():
 
 
 @router.get("/healthcheck-worker")
-def healthcheck_worker(db: Session = Depends(get_db)):
+def healthcheck_worker(db: Session = deps.db):
     """Returns a successful response if background workers are running."""
 
     msg = worker.ping.send()
@@ -64,7 +63,7 @@ def healthcheck_worker(db: Session = Depends(get_db)):
         }
     },
 )
-def whoami(context: CallContext = Depends(call_context)):
+def whoami(context: CallContext = deps.call_context):
     """Return basic information on the caller's authentication & authorization context.
 
     This endpoint may be used to determine whether the caller is authenticated to

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -5,12 +5,6 @@ from uuid import UUID
 from fastapi import Path
 from pydantic import BaseModel, Field, root_validator
 
-PathEnv = Path(
-    ...,
-    title="environment",
-    description="[Environment](#section/Environments) on which to operate.",
-)
-
 PathPublishId = Path(
     ...,
     title="publish ID",

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -44,6 +44,9 @@ class Settings(BaseSettings):
     db_service_port: str = "5432"
     """db service port"""
 
+    db_url: str = None
+    """Connection string for database. If set, overrides the ``db_service_*`` settings."""
+
     batch_size: int = 25
     """Maximum number of items to write at one time"""
     max_tries: int = 20

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -1,6 +1,5 @@
 import configparser
 import os
-from functools import lru_cache
 from typing import List
 
 from fastapi import HTTPException
@@ -61,14 +60,13 @@ class Settings(BaseSettings):
         env_prefix = "exodus_gw_"
 
 
-@lru_cache()
-def get_settings() -> Settings:
+def load_settings() -> Settings:
     """Return the currently active settings for the server.
 
-    This function is intended for use with fastapi.Depends.
+    This function will load settings from config files and environment
+    variables. It is intended to be called once at application startup.
 
-    Settings are loaded the first time this function is called, and cached
-    afterward.
+    Request handler functions should access settings via ``app.state.settings``.
     """
 
     settings = Settings()
@@ -105,12 +103,12 @@ def get_settings() -> Settings:
     return settings
 
 
-def get_environment(env: str):
+def get_environment(env: str, settings: Settings = None):
     """Return the corresponding environment object for the given environment
     name.
     """
 
-    settings = get_settings()
+    settings = settings or load_settings()
 
     for env_obj in settings.environments:
         if env_obj.name == env:

--- a/exodus_gw/worker/broker.py
+++ b/exodus_gw/worker/broker.py
@@ -9,7 +9,8 @@ from dramatiq.results.backends import StubBackend
 from dramatiq_pg.utils import transaction
 from psycopg2.errors import DuplicateSchema  # pylint: disable=E0611
 
-from exodus_gw.database import SQLALCHEMY_DATABASE_URL
+from exodus_gw.database import db_url
+from exodus_gw.settings import Settings
 
 LOG = logging.getLogger("exodus-gw")
 
@@ -71,7 +72,7 @@ class ExodusGwBroker(
     - can join the broker to an existing sqlalchemy session
     """
 
-    def __init__(self, url=SQLALCHEMY_DATABASE_URL, pool=None):
+    def __init__(self, url=None, pool=None):
         # Placeholder for pool context var.
         #
         # If the app sets a session on the broker, we'll start using this
@@ -82,6 +83,9 @@ class ExodusGwBroker(
         self.__pool_raw = None
 
         # Uses the same DB as used for sqlalchemy by default.
+        if not url and not pool:
+            url = db_url(Settings())
+
         super().__init__(url=url, pool=pool)
 
     @property

--- a/tests/app/test_db_session.py
+++ b/tests/app/test_db_session.py
@@ -4,7 +4,8 @@ from fastapi import Depends, HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from exodus_gw.database import SessionLocal, get_db
+from exodus_gw import deps
+from exodus_gw.database import SessionLocal
 from exodus_gw.main import app
 from exodus_gw.models import Publish
 
@@ -15,7 +16,7 @@ TEST_UUID = uuid.UUID("{12345678-1234-5678-1234-567812345678}")
 # A testing endpoint which will create an object and then commit,
 # rollback or raise based on params
 @app.post("/test_db_session/make_publish")
-def make_publish(mode: str = None, db: Session = Depends(get_db)):
+def make_publish(mode: str = None, db: Session = deps.db):
     p = Publish(id=TEST_UUID, env="test")
     db.add(p)
 

--- a/tests/app/test_db_session.py
+++ b/tests/app/test_db_session.py
@@ -1,11 +1,10 @@
 import uuid
 
-from fastapi import Depends, HTTPException
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from exodus_gw import deps
-from exodus_gw.database import SessionLocal
 from exodus_gw.main import app
 from exodus_gw.models import Publish
 
@@ -28,7 +27,7 @@ def make_publish(mode: str = None, db: Session = deps.db):
         raise HTTPException(500)
 
 
-def test_db_implicit_commit():
+def test_db_implicit_commit(db):
     """Commit occurs if request succeeds."""
 
     with TestClient(app) as client:
@@ -38,12 +37,11 @@ def test_db_implicit_commit():
     assert r.ok
 
     # Should have committed, even though we didn't explicitly request it
-    db = SessionLocal()
     publishes = db.query(Publish).filter(Publish.id == TEST_UUID)
     assert publishes.count() == 1
 
 
-def test_db_explicit_commit():
+def test_db_explicit_commit(db):
     """An explicit commit from within an endpoint works as expected."""
 
     with TestClient(app) as client:
@@ -53,12 +51,11 @@ def test_db_explicit_commit():
     assert r.ok
 
     # Should have committed, as requested
-    db = SessionLocal()
     publishes = db.query(Publish).filter(Publish.id == TEST_UUID)
     assert publishes.count() == 1
 
 
-def test_db_rollback():
+def test_db_rollback(db):
     """An explicit rollback from within an endpoint works as expected."""
 
     with TestClient(app) as client:
@@ -68,12 +65,11 @@ def test_db_rollback():
     assert r.ok
 
     # Should not have committed anything since we explicitly rolled back
-    db = SessionLocal()
     publishes = db.query(Publish).filter(Publish.id == TEST_UUID)
     assert publishes.count() == 0
 
 
-def test_db_rollback_on_raise():
+def test_db_rollback_on_raise(db):
     """Implicit rollback occurs if endpoint raises an exception."""
 
     with TestClient(app) as client:
@@ -83,6 +79,5 @@ def test_db_rollback_on_raise():
     assert not r.ok
 
     # Should not have committed anything since exception was raised
-    db = SessionLocal()
     publishes = db.query(Publish).filter(Publish.id == TEST_UUID)
     assert publishes.count() == 0

--- a/tests/auth/test_call_context.py
+++ b/tests/auth/test_call_context.py
@@ -13,7 +13,8 @@ def test_no_context():
     """Unauthenticated requests return a default context."""
 
     request = mock.Mock(headers={})
-    ctx = call_context(request, Settings())
+    request.app.state.settings = Settings()
+    ctx = call_context(request)
 
     # It should return a truthy object.
     assert ctx
@@ -46,8 +47,9 @@ def test_decode_context():
 
     settings = Settings(call_context_header="my-auth-header")
     request = mock.Mock(headers={"my-auth-header": b64})
+    request.app.state.settings = settings
 
-    ctx = call_context(request=request, settings=settings)
+    ctx = call_context(request=request)
 
     # The details should match exactly the encoded data from the header.
     assert ctx.client.roles == ["someRole", "anotherRole"]
@@ -75,9 +77,10 @@ def test_bad_header(header_value):
 
     settings = Settings(call_context_header="my-auth-header")
     request = mock.Mock(headers={"my-auth-header": header_value})
+    request.app.state.settings = settings
 
     with pytest.raises(HTTPException) as exc_info:
-        call_context(request=request, settings=settings)
+        call_context(request=request)
 
     # It should give a 400 error (client error)
     assert exc_info.value.status_code == 400

--- a/tests/database/test_db_url.py
+++ b/tests/database/test_db_url.py
@@ -1,0 +1,24 @@
+from exodus_gw.database import db_url
+from exodus_gw.settings import Settings
+
+
+def test_url_from_components():
+    settings = Settings(
+        db_service_user="user",
+        db_service_pass="pass",
+        db_service_host="somehost",
+        db_service_port=1122,
+        db_url=None,
+    )
+    assert db_url(settings) == "postgresql://user:pass@somehost:1122/user"
+
+
+def test_url_from_url():
+    settings = Settings(
+        db_service_user="user",
+        db_service_pass="pass",
+        db_service_host="somehost",
+        db_service_port=1122,
+        db_url="some://great-db",
+    )
+    assert db_url(settings) == "some://great-db"

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -3,8 +3,7 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from exodus_gw import models, routers, schemas
-from exodus_gw.database import SessionLocal
+from exodus_gw import routers, schemas
 from exodus_gw.main import app
 from exodus_gw.models import Publish
 from exodus_gw.settings import Environment, Settings
@@ -18,7 +17,7 @@ from exodus_gw.settings import Environment, Settings
         "test3",
     ],
 )
-def test_publish_env_exists(env):
+def test_publish_env_exists(env, db):
     with TestClient(app) as client:
         r = client.post("/%s/publish" % env)
 
@@ -28,7 +27,6 @@ def test_publish_env_exists(env):
     # Should have returned a publish object
     publish_id = r.json()["id"]
 
-    db = SessionLocal()
     publishes = db.query(Publish).filter(Publish.id == publish_id)
     assert publishes.count() == 1
 

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -7,7 +7,7 @@ from exodus_gw import models, routers, schemas
 from exodus_gw.database import SessionLocal
 from exodus_gw.main import app
 from exodus_gw.models import Publish
-from exodus_gw.settings import Environment
+from exodus_gw.settings import Environment, Settings
 
 
 @pytest.mark.parametrize(
@@ -111,7 +111,10 @@ async def test_commit_publish(
 
     assert (
         await routers.publish.commit_publish(
-            env=env, publish_id=mock_publish.id, db=mock_db_session
+            env=env,
+            publish_id=mock_publish.id,
+            db=mock_db_session,
+            settings=Settings(),
         )
         == {}
     )
@@ -132,7 +135,10 @@ async def test_commit_publish_env_doesnt_exist(mock_publish, mock_db_session):
 
     with pytest.raises(HTTPException) as exc_info:
         await routers.publish.commit_publish(
-            env=env, publish_id=mock_publish.id, db=mock_db_session
+            env=env,
+            publish_id=mock_publish.id,
+            db=mock_db_session,
+            settings=Settings(),
         )
 
     assert exc_info.value.status_code == 404
@@ -149,7 +155,10 @@ async def test_commit_publish_write_failed(
     mock_write_batches.side_effect = [False, True]
 
     await routers.publish.commit_publish(
-        env="test", publish_id=mock_publish.id, db=mock_db_session
+        env="test",
+        publish_id=mock_publish.id,
+        db=mock_db_session,
+        settings=Settings(),
     )
 
     mock_write_batches.assert_has_calls(
@@ -171,7 +180,10 @@ async def test_commit_publish_entry_point_files_failed(
     mock_write_batches.side_effect = [True, False, True]
 
     await routers.publish.commit_publish(
-        env="test", publish_id=mock_publish.id, db=mock_db_session
+        env="test",
+        publish_id=mock_publish.id,
+        db=mock_db_session,
+        settings=Settings(),
     )
 
     mock_write_batches.assert_has_calls(

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -1,6 +1,5 @@
 import pytest
 from botocore.exceptions import ClientError
-from fastapi import HTTPException
 
 from exodus_gw.routers.upload import head
 from exodus_gw.settings import get_environment

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -3,6 +3,7 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
 from exodus_gw.routers.upload import head
+from exodus_gw.settings import get_environment
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
@@ -14,7 +15,7 @@ async def test_head(mock_aws_client):
     mock_aws_client.head_object.return_value = {"ETag": "a1b2c3"}
 
     response = await head(
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
     )
 
@@ -41,7 +42,7 @@ async def test_head_invalid_key(mock_aws_client):
     )
 
     response = await head(
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
     )
 
@@ -53,20 +54,3 @@ async def test_head_invalid_key(mock_aws_client):
 
     # It should fail
     assert response.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_head_invalid_env(mock_aws_client):
-    """Head for an invalid environment does not delegate to s3."""
-
-    with pytest.raises(HTTPException) as exc_info:
-        await head(
-            env="foo",
-            key=TEST_KEY,
-        )
-
-    # It should not delegate request to real S3
-    assert not mock_aws_client.put_object.called
-
-    # It should produce an error message
-    assert exc_info.value.detail == "Invalid environment='foo'"

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 from exodus_gw.aws.util import xml_response
 from exodus_gw.routers.upload import abort_multipart_upload, multipart_upload
+from exodus_gw.settings import get_environment
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
@@ -22,7 +23,7 @@ async def test_create_mpu(mock_aws_client):
 
     response = await multipart_upload(
         None,
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
         uploads="",
     )
@@ -80,7 +81,7 @@ async def test_complete_mpu(mock_aws_client):
 
     response = await multipart_upload(
         request=request,
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
         uploadId="my-better-upload",
         uploads=None,
@@ -123,7 +124,7 @@ async def test_bad_mpu_call():
     with pytest.raises(HTTPException) as exc_info:
         await multipart_upload(
             request=None,
-            env="test",
+            env=get_environment("test"),
             key=TEST_KEY,
             uploadId="oops",
             uploads="not valid to mix these args",
@@ -137,7 +138,7 @@ async def test_abort_mpu(mock_aws_client):
     """Aborting a multipart upload is correctly delegated to S3."""
 
     response = await abort_multipart_upload(
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
         uploadId="my-lame-upload",
     )

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -1,6 +1,5 @@
 import mock
 import pytest
-from fastapi import HTTPException
 
 from exodus_gw.routers.upload import upload
 from exodus_gw.settings import get_environment

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -3,6 +3,7 @@ import pytest
 from fastapi import HTTPException
 
 from exodus_gw.routers.upload import upload
+from exodus_gw.settings import get_environment
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
@@ -25,7 +26,7 @@ async def test_full_upload(mock_aws_client, mock_request_reader):
 
     response = await upload(
         request=request,
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
         uploadId=None,
         partNumber=None,
@@ -68,7 +69,7 @@ async def test_part_upload(mock_aws_client, mock_request_reader):
 
     response = await upload(
         request=request,
-        env="test",
+        env=get_environment("test"),
         key=TEST_KEY,
         uploadId="my-best-upload",
         partNumber=88,
@@ -93,35 +94,3 @@ async def test_part_upload(mock_aws_client, mock_request_reader):
 
     # It should have an empty body
     assert response.body == b""
-
-
-@pytest.mark.asyncio
-async def test_upload_invalid_env(mock_aws_client, mock_request_reader):
-    """Uploading to an invalid environment does not delegate to s3."""
-
-    mock_aws_client.put_object.return_value = {
-        "ETag": "a1b2c3",
-    }
-
-    request = mock.Mock(
-        headers={
-            "Content-MD5": "9d0568469d206c1aedf1b71f12f474bc",
-            "Content-Length": "10",
-        }
-    )
-    mock_request_reader.return_value = b"some bytes"
-
-    with pytest.raises(HTTPException) as exc_info:
-        await upload(
-            request=request,
-            env="foo",
-            key=TEST_KEY,
-            uploadId=None,
-            partNumber=None,
-        )
-
-    # It should not delegate request to real S3
-    assert not mock_aws_client.put_object.called
-
-    # It should produce an error message
-    assert exc_info.value.detail == "Invalid environment='foo'"

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,18 +1,13 @@
 import pytest
 from fastapi import HTTPException
 
-from exodus_gw.settings import get_environment, get_settings
-
-# Note: get_settings is wrapped in lru_cache.
-# During tests, we want to test the real original function
-# without caching, so we grab a reference to it here.
-get_settings = get_settings.__wrapped__
+from exodus_gw.settings import get_environment, load_settings
 
 
-def test_get_settings_default():
-    """get_settings returns an object with default settings present."""
+def test_load_settings_default():
+    """load_settings returns an object with default settings present."""
 
-    settings = get_settings()
+    settings = load_settings()
 
     assert settings.call_context_header == "X-RhApiPlatform-CallContext"
     assert [env.name for env in settings.environments] == [
@@ -24,8 +19,8 @@ def test_get_settings_default():
     assert settings.db_service_pass == "exodus-gw"
 
 
-def test_get_settings_override(monkeypatch):
-    """get_settings values can be overridden by environment variables.
+def test_load_settings_override(monkeypatch):
+    """load_settings values can be overridden by environment variables.
 
     This test shows/proves that the pydantic BaseSettings environment variable
     parsing feature is generally working. It is not necessary to add similar
@@ -34,7 +29,7 @@ def test_get_settings_override(monkeypatch):
 
     monkeypatch.setenv("EXODUS_GW_CALL_CONTEXT_HEADER", "my-awesome-header")
 
-    settings = get_settings()
+    settings = load_settings()
 
     # It should have used the value from environment.
     assert settings.call_context_header == "my-awesome-header"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import logging
 
-from exodus_gw.main import configure_loggers
+from exodus_gw.main import loggers_init
+from exodus_gw.settings import load_settings
 
 
 def test_log_levels():
@@ -8,7 +9,7 @@ def test_log_levels():
 
     logging.getLogger("old-logger").setLevel("DEBUG")
 
-    configure_loggers()
+    loggers_init(load_settings())
 
     # Should not alter existing loggers.
     assert logging.getLogger("old-logger").level == logging.DEBUG
@@ -29,7 +30,7 @@ def test_log_handler():
     root_handlers.clear()
     assert not root_handlers
 
-    configure_loggers()
+    loggers_init(load_settings())
 
     # Should now have one (1) StreamHandler.
     assert len(root_handlers) == 1


### PR DESCRIPTION
This PR refactors the lifecycle of three kinds of objects and makes
greater usage of the dependency injection system:

- DB engine
- Settings
- Environment

The motivation behind these changes is to increase testability.
With the previous approach for handling these objects, we had
several globals constructed once at import time, and sometimes
the dependency on these globals would be hidden.

That made it more difficult to test code since you could not
simply run code with different values for Settings and expect it
to work properly - while *some* code might respect the new
settings, other code might be using globals initialized from the
old settings. That led to some hacks in tests, like one of the tests
bypassing the settings LRU cache, and the sqlite fixture having
to re-initialize the global DB engine.

With these refactors we're much closer to having it set up so that
one can `monkeypatch.setenv("EXODUS_GW_WHATEVER", ...)`
from within a test and have it "just work" the way one would
expect.

This is relevant to upcoming changes relating to DB
migrations/alembic which I've found difficult to test while having
the global DB engine.