### PR TITLE
fixup: drop redundant constraints on primary key columns

### DIFF
--- a/exodus_gw/models.py
+++ b/exodus_gw/models.py
@@ -16,8 +16,6 @@ class Publish(Base):
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
-        unique=True,
-        nullable=False,
     )
     items = relationship("Item", back_populates="publish")
 
@@ -30,8 +28,6 @@ class Item(Base):
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
-        unique=True,
-        nullable=False,
     )
     web_uri = Column(String, nullable=False)
     object_key = Column(String, nullable=False)


### PR DESCRIPTION
It's not necessary to set unique or non-null constraints on
primary keys, because those are always unique and non-null.

This has been harmless, but this should be cleaned up for
alembic migrations to work more cleanly - otherwise, alembic
autogenerate will always detect that some uniqueness
constraints need to be created.