### PR TITLE
docs: fix most settings missing from deployment guide

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -67,7 +67,7 @@ Settings
 --------
 
 .. autoclass:: exodus_gw.settings.Settings()
-    :members: call_context_header
+    :members:
 
     exodus-gw may be configured by the following settings.
 

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -18,8 +18,9 @@ class Environment(object):
 class Settings(BaseSettings):
     # Settings for the server.
     #
-    # Each setting defined here can be overridden by an environment variable
-    # of the same name, prefixed with "EXODUS_GW_".
+    # Most settings defined here can be overridden by an environment variable
+    # of the same name, prefixed with "EXODUS_GW_". Please add doc strings only
+    # for those (and not for other computed fields, like 'environments'.)
 
     call_context_header: str = "X-RhApiPlatform-CallContext"
     """Name of the header from which to extract call context (for authentication
@@ -34,7 +35,7 @@ class Settings(BaseSettings):
     """Logging configuration in dictConfig schema."""
 
     environments: List[Environment] = []
-    """List of environment objects derived from exodus-gw.ini."""
+    # List of environment objects derived from exodus-gw.ini.
 
     db_service_user: str = "exodus-gw"
     """db service user name"""


### PR DESCRIPTION
We had disabled the usual behavior of listing all members here.
I think this was done because 'environments' is computed and can't
be set directly by env var, but this way it's too easy to forget
adding a useful setting to docs.

Let's just use the convention that we will include all documented
members in the docs, and simply don't put doc strings on those we
don't want to appear.