### PR TITLE
docs: add response models to improve accuracy of API reference

### DIFF
--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -95,6 +95,7 @@ async def publish(
 @router.put(
     "/{env}/publish/{publish_id}",
     status_code=200,
+    response_model=schemas.EmptyResponse,
 )
 async def update_publish_items(
     items: Union[schemas.ItemBase or List[schemas.ItemBase]],
@@ -121,6 +122,7 @@ async def update_publish_items(
 @router.post(
     "/{env}/publish/{publish_id}/commit",
     status_code=200,
+    response_model=schemas.EmptyResponse,
 )
 async def commit_publish(
     publish_id: UUID = schemas.PathPublishId,

--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -5,7 +5,7 @@ import logging
 from fastapi import APIRouter
 from sqlalchemy.orm import Session
 
-from .. import deps, worker
+from .. import deps, schemas, worker
 from ..auth import CallContext
 
 LOG = logging.getLogger("exodus-gw")
@@ -15,13 +15,13 @@ openapi_tag = {"name": "service", "description": __doc__}
 router = APIRouter(tags=[openapi_tag["name"]])
 
 
-@router.get("/healthcheck")
+@router.get("/healthcheck", response_model=schemas.MessageResponse)
 def healthcheck():
     """Returns a successful response if the service is running."""
     return {"detail": "exodus-gw is running"}
 
 
-@router.get("/healthcheck-worker")
+@router.get("/healthcheck-worker", response_model=schemas.MessageResponse)
 def healthcheck_worker(db: Session = deps.db):
     """Returns a successful response if background workers are running."""
 

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -62,3 +62,13 @@ class Publish(PublishBase):
 
     class Config:
         orm_mode = True
+
+
+class MessageResponse(BaseModel):
+    detail: str = Field(
+        ..., description="A human-readable message with additional info."
+    )
+
+
+class EmptyResponse(BaseModel):
+    """An empty object."""


### PR DESCRIPTION
Set response models to show when we are returning a "detail"
message, or just an empty object.

This doesn't make much difference, it just fixes some slight
inaccuracies in the API reference (e.g. some of these APIs were
previously shown with example responses of "null" while they
actually return an object).