### PR TITLE
docs: improve API reference accuracy and details

### DIFF
--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -5,7 +5,7 @@ import logging
 from fastapi import APIRouter
 from sqlalchemy.orm import Session
 
-from .. import deps, worker
+from .. import deps, schemas, worker
 from ..auth import CallContext
 
 LOG = logging.getLogger("exodus-gw")
@@ -15,13 +15,21 @@ openapi_tag = {"name": "service", "description": __doc__}
 router = APIRouter(tags=[openapi_tag["name"]])
 
 
-@router.get("/healthcheck")
+@router.get(
+    "/healthcheck",
+    response_model=schemas.MessageResponse,
+    responses={200: {"description": "Service is up"}},
+)
 def healthcheck():
     """Returns a successful response if the service is running."""
     return {"detail": "exodus-gw is running"}
 
 
-@router.get("/healthcheck-worker")
+@router.get(
+    "/healthcheck-worker",
+    response_model=schemas.MessageResponse,
+    responses={200: {"description": "Worker(s) are responding"}},
+)
 def healthcheck_worker(db: Session = deps.db):
     """Returns a successful response if background workers are running."""
 
@@ -43,7 +51,7 @@ def healthcheck_worker(db: Session = deps.db):
     response_model=CallContext,
     responses={
         200: {
-            "description": "returns caller's auth context",
+            "description": "Caller's auth context retrieved",
             "content": {
                 "application/json": {
                     "example": {

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -62,3 +62,13 @@ class Publish(PublishBase):
 
     class Config:
         orm_mode = True
+
+
+class MessageResponse(BaseModel):
+    detail: str = Field(
+        ..., description="A human-readable message with additional info."
+    )
+
+
+class EmptyResponse(BaseModel):
+    """An empty object."""


### PR DESCRIPTION
- ensure all endpoints use a response model, even if it's empty;
  fixes some API examples wrongly showing as "null".

- add more examples for inputs and outputs

- tweak writing style on examples to more closely match the
  style used for FastAPI's built-in examples

- fix incorrect usage of Union for PUT on publish, which prevented
  docs from showing both "single item" and "array of item" cases