### PR TITLE
devenv: fix dev services unable to verify connection to localstack

### DIFF
--- a/scripts/systemd/exodus-gw-uvicorn.service
+++ b/scripts/systemd/exodus-gw-uvicorn.service
@@ -11,6 +11,7 @@ Environment=EXODUS_GW_DB_SERVICE_PORT=3355
 Environment=EXODUS_GW_DB_SERVICE_HOST=localhost
 Environment=EXODUS_GW_S3_ENDPOINT_URL=https://localhost:3377
 Environment=EXODUS_GW_DYNAMODB_ENDPOINT_URL=https://localhost:3377
+Environment=REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 Restart=on-failure
 
 ExecStart=/bin/sh -c "cd ${EXODUS_GW_SRC_PATH}; \

--- a/scripts/systemd/exodus-gw-worker.service
+++ b/scripts/systemd/exodus-gw-worker.service
@@ -9,6 +9,7 @@ Environment=EXODUS_GW_SRC_PATH=%h/src/exodus-gw
 Environment=EXODUS_GW_DB_SERVICE_PORT=3355
 Environment=EXODUS_GW_DB_SERVICE_HOST=localhost
 Environment=EXODUS_GW_DYNAMODB_ENDPOINT_URL=https://localhost:3377
+Environment=REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 Restart=on-failure
 
 ExecStart=/bin/sh -c "cd ${EXODUS_GW_SRC_PATH}; \


### PR DESCRIPTION
The exodus-gw dev uvicorn and worker should trust the CA cert used
for localstack. Ensure we've set REQUESTS_CA_BUNDLE pointing at
the system-wide bundle so that this works.