### PR TITLE
refactor: move dramatiq initialization to middleware

### DIFF
--- a/exodus_gw/worker/middleware/__init__.py
+++ b/exodus_gw/worker/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .schema_init import SchemaInitMiddleware
+
+__all__ = ["SchemaInitMiddleware"]

--- a/exodus_gw/worker/middleware/schema_init.py
+++ b/exodus_gw/worker/middleware/schema_init.py
@@ -1,0 +1,36 @@
+import logging
+import os
+
+from dramatiq import Middleware
+from dramatiq_pg.utils import transaction
+
+LOG = logging.getLogger("exodus-gw")
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "schema.sql")
+
+
+class SchemaInitMiddleware(Middleware):
+    """Middleware to automatically deploy dramatiq schema in DB, if not already present,
+    during worker startup."""
+
+    # Arbitrary ID used for postgres advisory locks
+    LOCK_ID = 682834
+
+    def after_process_boot(self, broker):
+        with transaction(broker.pool) as cursor:
+            cursor.execute("select pg_advisory_lock(%s)", (self.LOCK_ID,))
+
+            cursor.execute(
+                "select count(1) from information_schema.tables where table_schema=%s",
+                ("dramatiq",),
+            )
+            have_dramatiq = cursor.fetchone()
+
+            if have_dramatiq[0]:
+                LOG.debug("dramatiq schema is already in place")
+                return
+
+            with open(SCHEMA_PATH, "rt") as f:
+                schema = f.read()
+            cursor.execute(schema)
+
+            LOG.info("Applied dramatiq schema from %s", SCHEMA_PATH)


### PR DESCRIPTION
Previously the dramatiq schema initialization was hooked into
'consume' on the broker.

It turns out this wasn't the best place to put it because this is
called once per queue per thread, so we'd run the initialization
code many more times than necessary, and in parallel.

We should be using middleware for this, since it's designed
specifically for this kind of "run some code on a certain event"
use-case, so let's do that. We no longer override consume(), and
instead install middleware which listens for 'process_boot'. This
happens once during startup, from the main thread.

Since we can still have multiple worker processes, it's still
possible for initialization to happen from different processes
at the same time, so let's also improve the handling of this to
cut down on misleading log messages:

- use an advisory lock so that only one worker can try to deploy
  the schema at a time
- ask the DB if relevant table exists before trying to apply the
  schema, so there's no exception in the typical case
- be less verbose in logs when schema is already in place