### PR TITLE
devenv: make dev-worker run just one process

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands=
 use_develop=true
 passenv=EXODUS_GW*
 commands=
-    dramatiq --watch exodus_gw exodus_gw.worker {posargs}
+    dramatiq --watch exodus_gw exodus_gw.worker -p 1 {posargs}
 
 [testenv:dev-server]
 use_develop=true


### PR DESCRIPTION
In the openshift deployment we only run a single worker process
per container. Tweak the settings in dev env to more closely
reproduce this so that the exodus-gw-worker unit behaves similarly
to one worker replica in prod.