### PR TITLE
Enforce object key format [RHELDST-4845]

### DIFF
--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -1,9 +1,17 @@
 import io
+import re
 from typing import AnyStr
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
 from defusedxml.ElementTree import fromstring
-from fastapi import Response
+from fastapi import HTTPException, Response
+
+
+def validate_object_key(key: str):
+    pattern = re.compile(r"[0-9a-f]{64}")
+
+    if not re.match(pattern, key):
+        raise HTTPException(400, detail="Invalid object key: '%s'" % key)
 
 
 def content_md5(request):

--- a/exodus_gw/crud.py
+++ b/exodus_gw/crud.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, Session, lazyload
 
 from . import models, schemas
+from .aws.util import validate_object_key
 from .settings import Environment
 
 
@@ -27,6 +28,8 @@ def update_publish(
         items = [items]
 
     for item in items:
+        validate_object_key(item.object_key)
+
         db.add(models.Item(**item.dict(), publish_id=publish_id))
 
     db.commit()

--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -73,6 +73,7 @@ from ..aws.util import (
     RequestReader,
     content_md5,
     extract_mpu_parts,
+    validate_object_key,
     xml_response,
 )
 from ..settings import Environment
@@ -196,6 +197,8 @@ async def object_put(env: Environment, key: str, request: Request):
     # Single-part upload handler: entire object is written via one PUT.
     reader = RequestReader.get_reader(request)
 
+    validate_object_key(key)
+
     async with s3_client(profile=env.aws_profile) as s3:
         response = await s3.put_object(
             Bucket=env.bucket,
@@ -216,6 +219,8 @@ async def complete_multipart_upload(
 
     LOG.debug("completing mpu for parts %s", parts)
 
+    validate_object_key(key)
+
     async with s3_client(profile=env.aws_profile) as s3:
         response = await s3.complete_multipart_upload(
             Bucket=env.bucket,
@@ -235,6 +240,8 @@ async def complete_multipart_upload(
 
 
 async def create_multipart_upload(env: Environment, key: str):
+    validate_object_key(key)
+
     async with s3_client(profile=env.aws_profile) as s3:
         response = await s3.create_multipart_upload(Bucket=env.bucket, Key=key)
 
@@ -254,6 +261,8 @@ async def multipart_put(
     request: Request,
 ):
     reader = RequestReader.get_reader(request)
+
+    validate_object_key(key)
 
     async with s3_client(profile=env.aws_profile) as s3:
         response = await s3.upload_part(
@@ -289,6 +298,8 @@ async def abort_multipart_upload(
     """
     LOG.debug("Abort %s", uploadId)
 
+    validate_object_key(key)
+
     async with s3_client(profile=env.aws_profile) as s3:
         await s3.abort_multipart_upload(
             Bucket=env.bucket, Key=key, UploadId=uploadId
@@ -307,6 +318,8 @@ async def head(
     key: str = Path(..., description="S3 object key"),
 ):
     """Retrieve metadata from an S3 object."""
+
+    validate_object_key(key)
 
     try:
         async with s3_client(profile=env.aws_profile) as s3:

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -17,7 +17,10 @@ from exodus_gw.aws import dynamodb
                         "PutRequest": {
                             "Item": {
                                 "web_uri": {"S": "/some/path"},
-                                "object_key": {"S": "abcde"},
+                                "object_key": {
+                                    "S": "0bacfc5268f9994065dd858ece3359fd"
+                                    "7a99d82af5be84202b8e84c2a5b07ffa"
+                                },
                                 "from_date": {"S": "2021-01-01T00:00:00.0"},
                             }
                         }
@@ -26,7 +29,10 @@ from exodus_gw.aws import dynamodb
                         "PutRequest": {
                             "Item": {
                                 "web_uri": {"S": "/other/path"},
-                                "object_key": {"S": "a1b2"},
+                                "object_key": {
+                                    "S": "e448a4330ff79a1b20069d436fae9480"
+                                    "6a0e2e3a6b309cd31421ef088c6439fb"
+                                },
                                 "from_date": {"S": "2021-01-01T00:00:00.0"},
                             }
                         }
@@ -35,7 +41,10 @@ from exodus_gw.aws import dynamodb
                         "PutRequest": {
                             "Item": {
                                 "web_uri": {"S": "/to/repomd.xml"},
-                                "object_key": {"S": "c3d4"},
+                                "object_key": {
+                                    "S": "3f449eb3b942af58e9aca4c1cffdef89"
+                                    "c3f1552c20787ae8c966767a1fedd3a5"
+                                },
                                 "from_date": {"S": "2021-01-01T00:00:00.0"},
                             }
                         }
@@ -51,7 +60,10 @@ from exodus_gw.aws import dynamodb
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/some/path"},
-                                "object_key": {"S": "abcde"},
+                                "object_key": {
+                                    "S": "0bacfc5268f9994065dd858ece3359fd"
+                                    "7a99d82af5be84202b8e84c2a5b07ffa"
+                                },
                                 "from_date": {"S": "2021-01-01T00:00:00.0"},
                             }
                         }
@@ -60,7 +72,10 @@ from exodus_gw.aws import dynamodb
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/other/path"},
-                                "object_key": {"S": "a1b2"},
+                                "object_key": {
+                                    "S": "e448a4330ff79a1b20069d436fae9480"
+                                    "6a0e2e3a6b309cd31421ef088c6439fb"
+                                },
                                 "from_date": {"S": "2021-01-01T00:00:00.0"},
                             }
                         }
@@ -69,7 +84,10 @@ from exodus_gw.aws import dynamodb
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/to/repomd.xml"},
-                                "object_key": {"S": "c3d4"},
+                                "object_key": {
+                                    "S": "3f449eb3b942af58e9aca4c1cffdef89"
+                                    "c3f1552c20787ae8c966767a1fedd3a5"
+                                },
                                 "from_date": {"S": "2021-01-01T00:00:00.0"},
                             }
                         }

--- a/tests/aws/test_validate_object_key.py
+++ b/tests/aws/test_validate_object_key.py
@@ -1,0 +1,12 @@
+import pytest
+from fastapi import HTTPException
+
+from exodus_gw.aws.util import validate_object_key
+
+
+def test_invalid_object_key():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_object_key(key="foooooo")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid object key: 'foooooo'"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,17 +54,17 @@ def mock_item_list():
     return [
         schemas.ItemBase(
             web_uri="/some/path",
-            object_key="abcde",
+            object_key="0bacfc5268f9994065dd858ece3359fd7a99d82af5be84202b8e84c2a5b07ffa",
             from_date="2021-01-01T00:00:00.0",
         ),
         schemas.ItemBase(
             web_uri="/other/path",
-            object_key="a1b2",
+            object_key="e448a4330ff79a1b20069d436fae94806a0e2e3a6b309cd31421ef088c6439fb",
             from_date="2021-01-01T00:00:00.0",
         ),
         schemas.ItemBase(
             web_uri="/to/repomd.xml",
-            object_key="c3d4",
+            object_key="3f449eb3b942af58e9aca4c1cffdef89c3f1552c20787ae8c966767a1fedd3a5",
             from_date="2021-01-01T00:00:00.0",
         ),
     ]


### PR DESCRIPTION
This commit adds validation for outgoing object keys, esuring all object
keys to be uploaded or published are of sha256 format.