### PR TITLE
tests: disable check_same_thread with sqlite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,9 @@ def sqlite_in_tests(monkeypatch):
         # no problem
         pass
 
-    monkeypatch.setenv("EXODUS_GW_DB_URL", "sqlite:///%s" % filename)
+    monkeypatch.setenv(
+        "EXODUS_GW_DB_URL", "sqlite:///%s?check_same_thread=false" % filename
+    )
     yield
 
 


### PR DESCRIPTION
The sqlite driver by default will refuse to allow a connection
created by one thread to be used by another.

This doesn't play well with non-async endpoints, since they are
run via a threadpool and may be invoked from a different thread
from the final db.commit() after a request succeeds, which would
raise an exception.

Disabling this check appears to be safe, so let's do that.
Per [1], the default mode of sqlite is to be entirely thread-safe.
Per [2], the advice about disabling this check is:

> When using multiple threads with the same connection writing
> operations should be serialized by the user to avoid data corruption.

This is achieved since, although during the handling of a request we
may jump between threads to handle async vs non-async functions,
the setup with a request-scoped session still ensures we aren't
*using* the connection from multiple threads at once.

[1] https://sqlite.org/threadsafe.html
[2] https://docs.python.org/3/library/sqlite3.html