### PR TITLE
Introduce the concept of scheduled actors

### DIFF
--- a/exodus_gw/dramatiq/consumer.py
+++ b/exodus_gw/dramatiq/consumer.py
@@ -157,7 +157,10 @@ class Consumer(dramatiq.Consumer):
 
             body = db_message.body
             out = Message(
-                queue_name=db_message.queue, message_id=db_message.id, **body
+                queue_name=db_message.queue,
+                actor_name=db_message.actor,
+                message_id=db_message.id,
+                **body,
             )
 
             # Mark it as ours.
@@ -175,7 +178,6 @@ class Consumer(dramatiq.Consumer):
             < self.__settings.worker_keepalive_interval
             and not self.__queue_event.is_set()
         ):
-            LOG.debug("%s: too early for next consume", self.__consumer_id)
             return
 
         self.__last_consume = now

--- a/exodus_gw/dramatiq/middleware/__init__.py
+++ b/exodus_gw/dramatiq/middleware/__init__.py
@@ -1,4 +1,9 @@
 from .local_notify import LocalNotifyMiddleware
 from .pg_notify import PostgresNotifyMiddleware
+from .scheduler import SchedulerMiddleware
 
-__all__ = ["LocalNotifyMiddleware", "PostgresNotifyMiddleware"]
+__all__ = [
+    "LocalNotifyMiddleware",
+    "PostgresNotifyMiddleware",
+    "SchedulerMiddleware",
+]

--- a/exodus_gw/dramatiq/middleware/scheduler.py
+++ b/exodus_gw/dramatiq/middleware/scheduler.py
@@ -1,0 +1,150 @@
+import functools
+import logging
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import pycron
+from dramatiq import Middleware
+from dramatiq.common import dq_name
+from sqlalchemy.orm import Session
+
+from exodus_gw.models import DramatiqMessage
+from exodus_gw.settings import Settings
+
+LOG = logging.getLogger("exodus-gw")
+
+
+class SchedulerMiddleware(Middleware):
+    """Middleware allowing for scheduled actors with cron-style rules."""
+
+    # Arbitrary constant UUID used as namespace when calculating stable message IDs.
+    SCHEDULER_NS = uuid.UUID("71f64e5740d428a533429d81c30e899b")
+
+    def __init__(self, settings, db_engine):
+        self.__settings = settings
+        self.__db_engine = db_engine
+
+    @property
+    def actor_options(self):
+        return set(["scheduled"])
+
+    def __wrap_with_schedule(self, broker, actor):
+        # Wrap actor's callable so that it's invoked according to schedule.
+        #
+        # Scheduled callable behaves as follows:
+        #
+        # - a cron-style scheduling rule is looked up as Settings.cron_<actor_name>
+        #
+        # - whenever the scheduled callable is invoked, it calls the real actor only
+        #   if the cron rule has been hit since the last run
+        #
+        # - whenever the scheduled callable completes, it schedules itself again
+        #   after Settings.scheduler_interval
+        #
+        # Note, scheduled callable doesn't do anything in particular with errors, so
+        # those will be processed via the usual retry mechanism.
+
+        settings_key = "cron_" + actor.actor_name
+
+        # It is a bug to define a scheduled actor without a corresponding setting.
+        assert hasattr(self.__settings, settings_key)
+
+        actor.options["scheduled_message_id"] = uuid.uuid5(
+            self.SCHEDULER_NS, "-".join([actor.queue_name, actor.actor_name])
+        )
+
+        LOG.info(
+            "Scheduled actor %s uses message %s",
+            actor.actor_name,
+            actor.options["scheduled_message_id"],
+        )
+
+        unscheduled_fn = actor.fn
+
+        # Keep a reference to the original unwrapped function; we do this
+        # mainly to make testing easier as it is quite inconvenient to require
+        # all tests to set up the current time & cron rule just to invoke
+        # an actor.
+        actor.options["unscheduled_fn"] = unscheduled_fn
+
+        @functools.wraps(unscheduled_fn)
+        def new_fn(last_run: Optional[float] = None):
+            cron_rule = getattr(self.__settings, settings_key)
+            now = datetime.utcnow()
+
+            if not last_run:
+                # If we are being invoked for the first time, there is no obvious
+                # 'since' timestamp to use when evaluating the cron rule. We'll
+                # pick 30 minutes somewhat arbitrarily.
+                last_run = now.timestamp() - 60 * 30
+
+            since = datetime.fromtimestamp(last_run)
+
+            if pycron.has_been(cron_rule, since, now):
+                LOG.info(
+                    "Scheduled actor %s activated (rule: '%s', period: %s .. %s)",
+                    actor.actor_name,
+                    cron_rule,
+                    since,
+                    now,
+                )
+                unscheduled_fn()
+            else:
+                # Nothing to do right now, too early for next invoke.
+                LOG.debug(
+                    "Scheduled actor %s: cron '%s' did not occur within %s .. %s",
+                    actor.actor_name,
+                    cron_rule,
+                    since,
+                    now,
+                )
+
+            # Call ourselves again soon.
+            actor.send_with_options(
+                kwargs=dict(last_run=now.timestamp()),
+                delay=self.__settings.scheduler_interval * 60 * 1000,
+            )
+
+        actor.fn = new_fn
+
+    def before_declare_actor(self, broker, actor):
+        if not actor.options.get("scheduled"):
+            # nothing to do
+            return
+
+        self.__wrap_with_schedule(broker, actor)
+
+    def __ensure_enqueued(self, broker, actor, *args, **kwargs):
+        msg = actor.message(*args, **kwargs)
+
+        # Use a fixed message ID for this actor; this ensures there's only one
+        # scheduler message in the system for this actor.
+        msg = msg.copy(message_id=actor.options["scheduled_message_id"])
+
+        session = Session(bind=self.__db_engine)
+        try:
+            broker.set_session(session)
+
+            # Enqueue ourselves
+            broker.enqueue(msg, delay=Settings().scheduler_delay * 60 * 1000)
+
+            # Clean any other messages to same actor & queue which are NOT this one
+            queues = [actor.queue_name, dq_name(actor.queue_name)]
+            session.query(DramatiqMessage).filter(
+                DramatiqMessage.actor == actor.actor_name,
+                DramatiqMessage.queue.in_(queues),
+                DramatiqMessage.id != msg.message_id,
+            ).delete(synchronize_session=False)
+
+            # And commit
+            session.commit()
+        finally:
+            session.close()
+            broker.set_session(None)
+
+    def after_process_boot(self, broker):
+        for actor_name in broker.get_declared_actors():
+            actor = broker.get_actor(actor_name)
+            if actor.options.get("scheduled"):
+                self.__ensure_enqueued(broker, actor)

--- a/exodus_gw/migrations/versions/a60131dd10c4_.py
+++ b/exodus_gw/migrations/versions/a60131dd10c4_.py
@@ -1,0 +1,39 @@
+"""Add actor to dramatiq messages
+
+Revision ID: a60131dd10c4
+Revises: 0a3a709da247
+Create Date: 2021-02-15 11:35:58.851579
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a60131dd10c4"
+down_revision = "0a3a709da247"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # clean all messages first to avoid crashing on null actor
+    op.execute("DELETE FROM dramatiq_messages")
+
+    with op.batch_alter_table(
+        "dramatiq_messages",
+        # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
+        # on sqlite < 3.32.0
+        recreate="always",
+    ) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "actor",
+                sa.String(),
+                nullable=False,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("dramatiq_messages") as batch_op:
+        batch_op.drop_column("actor")

--- a/exodus_gw/models/dramatiq.py
+++ b/exodus_gw/models/dramatiq.py
@@ -32,6 +32,9 @@ class DramatiqMessage(Base):
     # Name of queue (e.g. "default" for most messages)
     queue = Column(String, nullable=False)
 
+    # Name of actor
+    actor = Column(String, nullable=False)
+
     # Full message body.
     body = Column(JSONB, nullable=False)
 

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -112,6 +112,23 @@ class Settings(BaseSettings):
     worker_keepalive_interval: int = 60
     """How often, in seconds, should background workers update their status."""
 
+    cron_cleanup: str = "0 */12 * * *"
+    """cron-style schedule for cleanup task.
+
+    exodus-gw will run a cleanup task approximately according to this schedule, removing old
+    data from the system."""
+
+    scheduler_interval: int = 15
+    """How often, in minutes, exodus-gw should check if a scheduled task is ready to run.
+
+    Note that the cron rules applied to each scheduled task are only as accurate as this
+    interval allows, i.e. each rule may be triggered up to ``scheduler_interval`` minutes late.
+    """
+
+    scheduler_delay: int = 5
+    """Delay, in minutes, after exodus-gw workers start up before any scheduled tasks
+    should run."""
+
     class Config:
         env_prefix = "exodus_gw_"
 

--- a/exodus_gw/worker/__init__.py
+++ b/exodus_gw/worker/__init__.py
@@ -4,4 +4,8 @@ from exodus_gw.dramatiq import Broker
 
 dramatiq.set_broker(Broker())
 
+# Imports must occur after the broker is set.
+# flake8 complains about that, hence the noqa.
+
 from .publish import commit  # noqa
+from .scheduled import cleanup  # noqa

--- a/exodus_gw/worker/scheduled.py
+++ b/exodus_gw/worker/scheduled.py
@@ -1,0 +1,16 @@
+import logging
+
+import dramatiq
+
+LOG = logging.getLogger("exodus-gw")
+
+
+@dramatiq.actor(scheduled=True)
+def cleanup():
+    # TODO: implement me.
+    #
+    # We must first implement:
+    # - timestamps on task and publish objects
+    # - state on publish objects
+    #
+    LOG.warning("Would do cleanup now")

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ async-exit-stack
 async-generator
 backoff
 dramatiq[watch]
+pycron

--- a/requirements.txt
+++ b/requirements.txt
@@ -347,6 +347,9 @@ psycopg2==2.8.6 \
     --hash=sha256:f974c96fca34ae9e4f49839ba6b78addf0346777b46c4da27a7bf54f48d3057d \
     --hash=sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543
     # via -r requirements.in
+pycron==3.0.0 \
+    --hash=sha256:b916044e3e8253d5409c68df3ac64a3472c4e608dab92f40e8f595e5d3acb3de
+    # via -r requirements.in
 pydantic==1.7.3 \
     --hash=sha256:025bf13ce27990acc059d0c5be46f416fc9b293f45363b3d19855165fee1874f \
     --hash=sha256:185e18134bec5ef43351149fe34fda4758e53d05bb8ea4d5928f0720997b79ef \

--- a/tests/dramatiq/test_broker.py
+++ b/tests/dramatiq/test_broker.py
@@ -26,14 +26,14 @@ def test_enqueue(db):
     # It shouldn't be associated with any consumer yet.
     assert message.consumer_id is None
 
-    # It should have recorded the correct queue
+    # It should have recorded the correct actor and queue
+    assert message.actor == "some_fn"
     assert message.queue == "some-queue"
 
     # Message body should have all the expected elements
     # (won't test specific timestamp value)
     assert message.body.pop("message_timestamp")
     assert message.body == {
-        "actor_name": "some_fn",
         "args": [1],
         "kwargs": {"y": "hello"},
         "options": {},

--- a/tests/dramatiq/test_scheduler.py
+++ b/tests/dramatiq/test_scheduler.py
@@ -1,0 +1,165 @@
+import uuid
+from datetime import datetime
+from unittest import mock
+
+import dramatiq
+import pytest
+from fastapi.testclient import TestClient
+
+from exodus_gw.dramatiq import Broker
+from exodus_gw.main import app
+from exodus_gw.models import DramatiqMessage
+from exodus_gw.settings import Settings
+
+
+class ExtendedSettings(Settings):
+    cron_schedule_test1: str = ""
+    cron_schedule_test2: str = ""
+
+
+@pytest.fixture
+def mock_utcnow():
+    with mock.patch(
+        "exodus_gw.dramatiq.middleware.scheduler.datetime"
+    ) as mock_datetime:
+        mock_datetime.fromtimestamp.side_effect = datetime.fromtimestamp
+        yield mock_datetime.utcnow
+
+
+def test_scheduled_actor_invoked_on_rule_match(mock_utcnow):
+    """Scheduled actors only get invoked when cron rule from settings is matched."""
+
+    settings = ExtendedSettings()
+    settings.cron_schedule_test1 = "5 1,2,3 * * *"
+    broker = Broker(settings=settings)
+
+    calls = []
+
+    @dramatiq.actor(scheduled=True, broker=broker)
+    def schedule_test1():
+        calls.append(True)
+
+    with TestClient(app):
+        now = datetime(1999, 1, 1)
+        mock_utcnow.return_value = now
+
+        # First call does not match the cron rule
+        schedule_test1.fn()
+
+        # So it shouldn't trigger the underlying actor
+        assert not calls
+
+        # Set time to 1:07, just after 1:05 hitting the cron rule
+        now = now.replace(hour=1, minute=7)
+        mock_utcnow.return_value = now
+
+        # Now it should hit the rule if looking back a few minutes
+        schedule_test1.fn(now.timestamp() - 120.0)
+        assert len(calls) == 1
+
+        # While looking back 30 seconds should not
+        schedule_test1.fn(now.timestamp() - 30.0)
+        assert len(calls) == 1
+
+        # Same at 3:07
+        now = now.replace(hour=3)
+        mock_utcnow.return_value = now
+        schedule_test1.fn(now.timestamp() - 120.0)
+        assert len(calls) == 2
+
+        # But no match at 4:07
+        now = now.replace(hour=4)
+        mock_utcnow.return_value = now
+        schedule_test1.fn(now.timestamp() - 120.0)
+        assert len(calls) == 2
+
+
+def test_scheduled_actor_enqueued_on_startup(db):
+    """Scheduled actors automatically get enqueued/reset when broker boots."""
+
+    settings = ExtendedSettings()
+    settings.cron_schedule_test1 = "5 1,2,3 * * *"
+    settings.cron_schedule_test2 = "5 1,2,3 * * *"
+    broker = Broker(settings=settings)
+
+    @dramatiq.actor(scheduled=True, broker=broker)
+    def schedule_test1():
+        pass
+
+    @dramatiq.actor(scheduled=True, broker=broker)
+    def schedule_test2():
+        pass
+
+    with TestClient(app):
+        # Simulate that some messages already exist when
+        # broker starts up.
+        db.add(
+            DramatiqMessage(
+                id=uuid.uuid4(),
+                queue="default",
+                actor="schedule_test1",
+                body={},
+            )
+        )
+        db.add(
+            DramatiqMessage(
+                id=uuid.uuid4(),
+                queue="default",
+                actor="schedule_test1",
+                body={},
+            )
+        )
+        db.add(
+            DramatiqMessage(
+                id=uuid.uuid4(),
+                queue="default",
+                actor="schedule_test2",
+                body={},
+            )
+        )
+
+        # There can be messages for unrelated actors too.
+        db.add(
+            DramatiqMessage(
+                id=uuid.UUID("f3d9ae4aeea6946a8668445395ba10b7"),
+                queue="default",
+                actor="other_actor",
+                body={},
+            )
+        )
+
+        db.commit()
+
+        # Boot up the broker.
+        broker.emit_after("process_boot")
+
+        # Now check DB state:
+        db.expire_all()
+        db_messages = sorted(
+            db.query(DramatiqMessage).all(), key=lambda msg: msg.actor
+        )
+
+        raw_messages = [(str(m.id), m.queue, m.actor) for m in db_messages]
+
+        # During boot, it should clean existing scheduled messages and
+        # ensure exactly one message per scheduled actor, leaving us with
+        # three messages:
+        assert raw_messages == [
+            # The message unrelated to scheduler is left untouched
+            ("f3d9ae4a-eea6-946a-8668-445395ba10b7", "default", "other_actor"),
+            # Then one message per scheduled actor.
+            # Note: messages go to delayed queue (DQ) since they are delayed messages.
+            # Note: it is correct that UUIDs are hardcoded here even though random
+            # ones were used above. The system uses a fixed UUID for the initial
+            # message per scheduled actor.
+            (
+                "b343626c-8d3a-50b3-9624-f18e61020dce",
+                "default.DQ",
+                "schedule_test1",
+            ),
+            (
+                "dbe98881-cac5-5446-9dd9-1912cae1c71c",
+                "default.DQ",
+                "schedule_test2",
+            ),
+        ]

--- a/tests/worker/test_cleanup.py
+++ b/tests/worker/test_cleanup.py
@@ -1,0 +1,15 @@
+from exodus_gw.worker import cleanup
+
+# cleanup is a scheduled actor, we want to test the actor itself
+# and not the scheduling mechanism, so unwrap it to get at the
+# implementation.
+
+cleanup = cleanup.options["unscheduled_fn"]
+
+
+def test_cleanup_noop():
+    """Calling cleanup doesn't crash."""
+
+    # Actual implementation doesn't exist yet so we don't have
+    # any more meaningful test right now.
+    cleanup()


### PR DESCRIPTION
This commit implements middleware for having actors scheduled by
cron-style rules. It will be used for periodic cleanup.

Scheduled actors work as follows:

- use @dramatiq.actor(scheduled=True) to declare actor

- Settings class must have a "cron_<actor_name>" key which holds
  a cron-style rule (e.g. "0 */2 * * *" for "every two hours, at 0
  past the hour)

- middleware wraps the actor in a function which arranges for itself
  to be called every Settings.scheduler_interval minutes, and only
  invokes the real actor if the cron rule triggered since the last
  run

- middleware ensures one call to this wrapped actor is enqueued during
  worker startup.

The end result is that the actor will be automatically executed
approximately according to the associated cron rule.

This is expected to be used by a scheduled cleanup task to erase old
or abandoned publish and task objects. Right now, an empty cleanup
actor has been provided as it is not possible to implement it yet
without a few other changes first.