### PR TITLE
Fix usage of blocking DB session from async functions [RHELDST-4857]

### DIFF
--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -100,7 +100,7 @@ router = APIRouter(tags=[openapi_tag["name"]])
         }
     },
 )
-async def publish(
+def publish(
     env: Environment = deps.env, db: Session = deps.db
 ) -> models.Publish:
     """Creates and returns a new publish object."""
@@ -113,7 +113,7 @@ async def publish(
     status_code=200,
     response_model=schemas.EmptyResponse,
 )
-async def update_publish_items(
+def update_publish_items(
     items: Union[schemas.ItemBase, List[schemas.ItemBase]] = Body(
         ...,
         example=[

--- a/tests/async_utils.py
+++ b/tests/async_utils.py
@@ -1,0 +1,66 @@
+import threading
+from functools import wraps
+
+
+def assert_not_main_thread(message):
+    """Assert that we are not currently in the main thread.
+
+    'message' should briefly summarize what we are currently doing (e.g. "call foo").
+    It'll be included in the error message.
+    """
+
+    thread = threading.currentThread()
+    if thread != threading.main_thread():
+        # OK, fine
+        return
+
+    raise AssertionError(
+        "Attempted to %s from within main thread - using blocking function from async?"
+        % message
+    )
+
+
+def ensuring_nonblock(fn):
+    """Return a version of 'fn' wrapped with an assertion that we're not in the
+    main thread.
+    """
+
+    @wraps(fn)
+    def new_fn(*args, **kwargs):
+        assert_not_main_thread("invoke %s" % fn)
+        return fn(*args, **kwargs)
+
+    return new_fn
+
+
+class BlockDetector:
+    """A helper to wrap an object with assertions protecting against
+    certain kinds of async bugs.
+
+    Some objects, such as an sqlalchemy session, are not designed with
+    an async API and will perform potentially slow operations during
+    use, e.g. communicating with a remote server during 'commit'.
+    Those objects shouldn't be used from within an 'async' endpoint,
+    or if used, should be done by calling out to a separate thread.
+
+    This wrapper helps to enforce correct usage of such objects while
+    tests are running. When accessed through the main thread, an assertion
+    will be raised, generally indicating that an object was wrongly used
+    from within an 'async' function. When accessed through any other
+    thread, it behaves as the underlying object, as if there were no
+    wrapper.
+    """
+
+    def __init__(self, delegate):
+        self.__delegate = delegate
+
+    def __getattr__(self, name):
+        # Get attribute from the real object.
+        out = getattr(self.__delegate, name)
+
+        # If it was a function, wrap it such that it will raise if called
+        # from within the main thread.
+        if callable(out):
+            out = ensuring_nonblock(out)
+
+        return out

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -43,9 +43,8 @@ def test_publish_env_doesnt_exist():
     assert r.json() == {"detail": "Invalid environment='foo'"}
 
 
-@pytest.mark.asyncio
-async def test_publish_links(mock_db_session):
-    publish = await routers.publish.publish(
+def test_publish_links(mock_db_session):
+    publish = routers.publish.publish(
         env=Environment("test", "some-profile", "some-bucket", "some-table"),
         db=mock_db_session,
     )
@@ -107,7 +106,6 @@ def test_update_publish_items_typical(db):
     ]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "env",
     [
@@ -116,7 +114,7 @@ def test_update_publish_items_typical(db):
         "test3",
     ],
 )
-async def test_update_publish_items_env_exists(env, mock_db_session):
+def test_update_publish_items_env_exists(env, mock_db_session):
     test_items = [
         schemas.ItemBase(
             web_uri="/some/path",
@@ -141,7 +139,7 @@ async def test_update_publish_items_env_exists(env, mock_db_session):
     env = Environment(env, "test-profile", "test-bucket", "test-table")
 
     assert (
-        await routers.publish.update_publish_items(
+        routers.publish.update_publish_items(
             env=env,
             publish_id=publish_id,
             items=items,


### PR DESCRIPTION
sqlalchemy's session is not designed for use with async. Using any
of its blocking methods from within an async function could block
the entire service for the duration (e.g. if a db.commit() in one
request were to take five seconds, the service would effectively
hang and not process any other requests for those five seconds).

Fix it so that usage of the session never blocks the main thread.
Achieved in two ways:

- for endpoints using the DB, they simply shouldn't be defined with
  async. This will make FastAPI run them via a threadpool.

- for the DB usage within middleware, which has to be async,
  explicitly call the close/commit functions via a threadpool.

This kind of bug would be easy to reintroduce, as the symptoms
are only some mysterious slowness which is probably too slight
to notice during casual testing. To help protect against further
mistakes, a fixture was added which wraps DB sessions during tests
using TestClient. The wrapper will enforce that the DB session
is not being used from the main thread.