### PR TITLE
Add missing 'async' in various places, reduce unneeded threads [RHELDST-4857]

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -36,7 +36,7 @@ class CallContext(BaseModel):
     user: UserContext = UserContext()
 
 
-def call_context(request: Request) -> CallContext:
+async def call_context(request: Request) -> CallContext:
     """Returns the CallContext for the current request."""
 
     settings = request.app.state.settings
@@ -54,7 +54,9 @@ def call_context(request: Request) -> CallContext:
         raise HTTPException(400, detail=summary) from None
 
 
-def caller_roles(context: CallContext = Depends(call_context)) -> Set[str]:
+async def caller_roles(
+    context: CallContext = Depends(call_context),
+) -> Set[str]:
     """Returns all roles held by the caller of the current request.
 
     This will be an empty set for unauthenticated requests.
@@ -76,7 +78,7 @@ def needs_role(rolename):
     >    "If caller does not have role xyz, they will never get here."
     """
 
-    def check_roles(roles: Set[str] = Depends(caller_roles)):
+    async def check_roles(roles: Set[str] = Depends(caller_roles)):
         if rolename not in roles:
             raise HTTPException(
                 403, "this operation requires role '%s'" % rolename

--- a/exodus_gw/deps.py
+++ b/exodus_gw/deps.py
@@ -6,16 +6,16 @@ from .auth import call_context as get_call_context
 from .settings import Settings, get_environment
 
 
-def get_db(request: Request):
+async def get_db(request: Request):
     """DB session accessor for use with FastAPI's dependency injection system."""
     return request.state.db
 
 
-def get_settings(request: Request):
+async def get_settings(request: Request):
     return request.app.state.settings
 
 
-def get_environment_from_path(
+async def get_environment_from_path(
     env: str = Path(
         ...,
         title="environment",

--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -24,7 +24,7 @@ router = APIRouter(tags=[openapi_tag["name"]])
     response_model=schemas.MessageResponse,
     responses={200: {"description": "Service is up"}},
 )
-def healthcheck():
+async def healthcheck():
     """Returns a successful response if the service is running."""
     return {"detail": "exodus-gw is running"}
 
@@ -81,7 +81,7 @@ def healthcheck_worker(
         }
     },
 )
-def whoami(context: CallContext = deps.call_context):
+async def whoami(context: CallContext = deps.call_context):
     """Return basic information on the caller's authentication & authorization context.
 
     This endpoint may be used to determine whether the caller is authenticated to

--- a/tests/auth/test_roles.py
+++ b/tests/auth/test_roles.py
@@ -10,39 +10,43 @@ from exodus_gw.auth import (
 )
 
 
-def test_caller_roles_empty():
+@pytest.mark.asyncio
+async def test_caller_roles_empty():
     """caller_roles returns an empty set for a default (empty) context."""
 
-    assert caller_roles(CallContext()) == set()
+    assert (await caller_roles(CallContext())) == set()
 
 
-def test_caller_roles_nonempty():
+@pytest.mark.asyncio
+async def test_caller_roles_nonempty():
     """caller_roles returns all roles from the context when present."""
 
     ctx = CallContext(
         user=UserContext(roles=["role1", "role2"]),
         client=ClientContext(roles=["role2", "role3"]),
     )
-    assert caller_roles(ctx) == set(["role1", "role2", "role3"])
+    assert (await caller_roles(ctx)) == set(["role1", "role2", "role3"])
 
 
-def test_needs_role_success():
+@pytest.mark.asyncio
+async def test_needs_role_success():
     """needs_role succeeds when needed role is present."""
 
     fn = needs_role("better-role").dependency
 
     # It should do nothing, successfully
-    fn(roles=set(["better-role"]))
+    await fn(roles=set(["better-role"]))
 
 
-def test_needs_role_fail():
+@pytest.mark.asyncio
+async def test_needs_role_fail():
     """needs_role raises meaningful error when needed role is absent."""
 
     fn = needs_role("best-role").dependency
 
     # It should raise an exception.
     with pytest.raises(HTTPException) as exc_info:
-        fn(roles=set(["abc", "xyz"]))
+        await fn(roles=set(["abc", "xyz"]))
 
     # It should use status 403 to tell the client they are unauthorized.
     assert exc_info.value.status_code == 403

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 from fastapi.testclient import TestClient
 
 from exodus_gw import models
@@ -8,8 +9,9 @@ from exodus_gw.models import DramatiqConsumer
 from exodus_gw.routers import service
 
 
-def test_healthcheck():
-    assert service.healthcheck() == {"detail": "exodus-gw is running"}
+@pytest.mark.asyncio
+async def test_healthcheck():
+    assert (await service.healthcheck()) == {"detail": "exodus-gw is running"}
 
 
 def test_healthcheck_worker_healthy(db):
@@ -48,11 +50,12 @@ def test_healthcheck_worker_unhealthy(db):
         assert r.json() == {"detail": "background workers unavailable"}
 
 
-def test_whoami():
+@pytest.mark.asyncio
+async def test_whoami():
     # All work is done by fastapi deserialization, so this doesn't actually
     # do anything except return the passed object.
     context = object()
-    assert service.whoami(context=context) is context
+    assert (await service.whoami(context=context)) is context
 
 
 def test_get_task(db):


### PR DESCRIPTION
In the case of both endpoints, and functions used with Depends, if they
don't use any blocking functionality then we should mark them as
async.

We should do this because otherwise FastAPI is pessimistic: it assumes
any non-async function might block, and so runs it in a threadpool.
This works but is rather wasteful to do this for every dependency
when not needed.