### PR TITLE
Fix broken migrations - 'DependentObjectsStillExist'

### DIFF
--- a/exodus_gw/migrations/versions/854e06069e65_.py
+++ b/exodus_gw/migrations/versions/854e06069e65_.py
@@ -21,9 +21,6 @@ def upgrade():
 
     with op.batch_alter_table(
         "publishes",
-        # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
-        # on sqlite < 3.32.0
-        recreate="always",
     ) as batch_op:
         batch_op.add_column(
             sa.Column(


### PR DESCRIPTION
This was caused by migration version 854e06069e65 in which
batch_alter_table() in upgrade() used recreate="always". This forced a
drop of the publishes table which failed because Item objects still
existed which depended on Publish ids. This commit removes the recreate
argument.