### PR TITLE
Remove from_date Item attribute [RHELDST-4868]

### DIFF
--- a/examples/exodus-sync
+++ b/examples/exodus-sync
@@ -189,7 +189,6 @@ def publish_items(args, items):
                 {
                     "web_uri": item.dest_path,
                     "object_key": item.object_key,
-                    "from_date": "abc123",
                 }
                 for item in batch
             ],

--- a/exodus_gw/migrations/versions/55d4111a0e09_.py
+++ b/exodus_gw/migrations/versions/55d4111a0e09_.py
@@ -1,0 +1,42 @@
+"""Remove from_date column from items
+
+Revision ID: 55d4111a0e09
+Revises: c164c7b69e55
+Create Date: 2021-02-23 10:47:33.420762
+
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "55d4111a0e09"
+down_revision = "c164c7b69e55"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("items") as batch_op:
+        batch_op.drop_column("from_date")
+
+
+def downgrade():
+    # clean all items first to avoid crashing on null state
+    op.execute("DELETE FROM items")
+
+    # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
+    # on sqlite < 3.32.0
+    recreate = (
+        "always"
+        if "sqlite" in os.environ.get("EXODUS_GW_DB_URL", "")
+        else "auto"
+    )
+
+    with op.batch_alter_table("items", recreate=recreate) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "from_date", sa.VARCHAR(), autoincrement=False, nullable=False
+            ),
+        )

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -39,23 +39,8 @@ class Item(Base):
     )
     web_uri = Column(String, nullable=False)
     object_key = Column(String, nullable=False)
-    from_date = Column(String, nullable=False)
     publish_id = Column(
         UUID(as_uuid=True), ForeignKey("publishes.id"), nullable=False
     )
 
     publish = relationship("Publish", back_populates="items")
-
-    def aws_fmt(self, delete):
-        # Delete requests can only contain table keys, so leave others
-        # out for now.
-        result = {
-            "web_uri": {"S": self.web_uri},
-            "from_date": {"S": self.from_date},
-        }
-
-        if delete:
-            return result
-
-        result["object_key"] = {"S": self.object_key}
-        return result

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -59,6 +59,7 @@ Publish objects should be treated as ephemeral; they are not persisted indefinit
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import Dict, List, Union
 from uuid import UUID
 
@@ -204,7 +205,12 @@ def commit_publish(
             % (db_publish.id, db_publish.state),
         )
 
-    msg = worker.commit.send(publish_id=str(db_publish.id), env=env.name)
+    msg = worker.commit.send(
+        publish_id=str(db_publish.id),
+        env=env.name,
+        from_date=str(datetime.now(timezone.utc)),
+    )
+
     LOG.info("Enqueued commit for '%s'", msg.kwargs["publish_id"])
     db_publish.state = schemas.PublishStates.committing
 

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -31,8 +31,6 @@ class ItemBase(BaseModel):
         ),
     )
 
-    from_date: str
-
 
 class Item(ItemBase):
     publish_id: UUID = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,19 +106,16 @@ def fake_publish():
         models.Item(
             web_uri="/some/path",
             object_key="0bacfc5268f9994065dd858ece3359fd7a99d82af5be84202b8e84c2a5b07ffa",
-            from_date="2021-01-01T00:00:00.0",
             publish_id=publish.id,
         ),
         models.Item(
             web_uri="/other/path",
             object_key="e448a4330ff79a1b20069d436fae94806a0e2e3a6b309cd31421ef088c6439fb",
-            from_date="2021-01-01T00:00:00.0",
             publish_id=publish.id,
         ),
         models.Item(
             web_uri="/to/repomd.xml",
             object_key="3f449eb3b942af58e9aca4c1cffdef89c3f1552c20787ae8c966767a1fedd3a5",
-            from_date="2021-01-01T00:00:00.0",
             publish_id=publish.id,
         ),
     ]

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -50,7 +50,7 @@ def test_publish_links(mock_db_session):
         db=mock_db_session,
     )
 
-    # The schema (realistic result) resulting from the publish
+    # The schema (realistic result) of the publish
     # should contain accurate links.
     assert schemas.Publish(**publish.__dict__).links == {
         "self": "/test/publish/%s" % publish.id,
@@ -79,12 +79,10 @@ def test_update_publish_items_typical(db):
                 {
                     "web_uri": "/uri1",
                     "object_key": "1" * 64,
-                    "from_date": "date1",
                 },
                 {
                     "web_uri": "/uri2",
                     "object_key": "2" * 64,
-                    "from_date": "date2",
                 },
             ],
         )
@@ -95,7 +93,6 @@ def test_update_publish_items_typical(db):
     # publish object should now have matching items
     db.refresh(publish)
 
-    # (note: ignoring from_date because it's planned for removal from the request format)
     items = sorted(publish.items, key=lambda item: item.web_uri)
     item_dicts = [
         {"web_uri": item.web_uri, "object_key": item.object_key}
@@ -129,7 +126,6 @@ def test_update_publish_items_single_item(db):
             json={
                 "web_uri": "/uri1",
                 "object_key": "1" * 64,
-                "from_date": "date1",
             },
         )
 
@@ -139,7 +135,6 @@ def test_update_publish_items_single_item(db):
     # publish object should now have a matching item
     db.refresh(publish)
 
-    # (note: ignoring from_date because it's planned for removal from the request format)
     item_dicts = [
         {"web_uri": item.web_uri, "object_key": item.object_key}
         for item in publish.items
@@ -170,12 +165,10 @@ def test_update_pubish_items_invalid_publish(db):
                 {
                     "web_uri": "/uri1",
                     "object_key": "1" * 64,
-                    "from_date": "date1",
                 },
                 {
                     "web_uri": "/uri2",
                     "object_key": "2" * 64,
-                    "from_date": "date2",
                 },
             ],
         )
@@ -207,7 +200,9 @@ def test_commit_publish(mock_commit, fake_publish, db):
     mock_commit.assert_has_calls(
         calls=[
             mock.call.send(
-                publish_id="123e4567-e89b-12d3-a456-426614174000", env="test"
+                publish_id="123e4567-e89b-12d3-a456-426614174000",
+                env="test",
+                from_date=mock.ANY,
             )
         ],
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,12 +11,10 @@ def test_Item_init():
     item = Item(
         web_uri="/some/path",
         object_key="abcde",
-        from_date="2021-01-01T00:00:00.0",
         publish_id="123e4567-e89b-12d3-a456-426614174000",
     )
     assert item.web_uri == "/some/path"
     assert item.object_key == "abcde"
-    assert item.from_date == "2021-01-01T00:00:00.0"
     assert item.publish_id == "123e4567-e89b-12d3-a456-426614174000"
 
 


### PR DESCRIPTION
This commit removes the from_date attribute from the Item model and
schema so users are unable to set this field themselves, as there is
currently no use-case for them to do so.

The from_date attribute is still required by the DynamoDB table,
however, so it is programmatically set to the datetime at which
the item's parent publish is committed.