### PR TITLE
Fix DependentObjectsStillExist when running migrations on postgres

### DIFF
--- a/exodus_gw/migrations/versions/854e06069e65_.py
+++ b/exodus_gw/migrations/versions/854e06069e65_.py
@@ -5,6 +5,8 @@ Revises: a60131dd10c4
 Create Date: 2021-02-18 11:06:59.636314
 
 """
+import os
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -19,11 +21,17 @@ def upgrade():
     # clean all publishes first to avoid crashing on null state
     op.execute("DELETE FROM publishes")
 
+    # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
+    # on sqlite < 3.32.0
+    recreate = (
+        "always"
+        if "sqlite" in os.environ.get("EXODUS_GW_DB_URL", "")
+        else "auto"
+    )
+
     with op.batch_alter_table(
         "publishes",
-        # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
-        # on sqlite < 3.32.0
-        recreate="always",
+        recreate=recreate,
     ) as batch_op:
         batch_op.add_column(
             sa.Column(

--- a/exodus_gw/migrations/versions/a60131dd10c4_.py
+++ b/exodus_gw/migrations/versions/a60131dd10c4_.py
@@ -5,6 +5,8 @@ Revises: 0a3a709da247
 Create Date: 2021-02-15 11:35:58.851579
 
 """
+import os
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -19,11 +21,16 @@ def upgrade():
     # clean all messages first to avoid crashing on null actor
     op.execute("DELETE FROM dramatiq_messages")
 
+    # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
+    # on sqlite < 3.32.0
+    recreate = (
+        "always"
+        if "sqlite" in os.environ.get("EXODUS_GW_DB_URL", "")
+        else "auto"
+    )
+
     with op.batch_alter_table(
-        "dramatiq_messages",
-        # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
-        # on sqlite < 3.32.0
-        recreate="always",
+        "dramatiq_messages", recreate=recreate
     ) as batch_op:
         batch_op.add_column(
             sa.Column(


### PR DESCRIPTION
Migrations would fail with:

    psycopg2.errors.DependentObjectsStillExist: cannot drop constraint publishes_pkey on table publishes because other objects depend on it
    DETAIL:  constraint items_publish_id_fkey on table items depends on index publishes_pkey

Our usage of recreate='always', to work around an issue on older
versions of sqlite, triggered the problem. As that is an
sqlite-specific fix, let's apply it *only* when using sqlite and
otherwise leave the parameter at the default value of "auto".