### PR TITLE
Implement scheduled cleanup task [RHELDST-4843]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -20,7 +20,9 @@ class Publish(Base):
     env = Column(String, nullable=False)
     state = Column(String, nullable=False)
     updated = Column(DateTime(timezone=True))
-    items = relationship("Item", back_populates="publish")
+    items = relationship(
+        "Item", back_populates="publish", cascade="all, delete-orphan"
+    )
 
 
 @event.listens_for(Publish, "before_update")

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -47,6 +47,10 @@ class PublishStates(str, Enum):
     committed = "COMMITTED"
     failed = "FAILED"
 
+    @classmethod
+    def terminal(cls) -> List["PublishStates"]:
+        return [cls.committed, cls.failed]
+
 
 class PublishBase(BaseModel):
     id: UUID = Field(..., description="Unique ID of publish object.")
@@ -87,6 +91,10 @@ class TaskStates(str, Enum):
     in_progress = "IN_PROGRESS"
     complete = "COMPLETE"
     failed = "FAILED"
+
+    @classmethod
+    def terminal(cls) -> List["TaskStates"]:
+        return [cls.failed, cls.complete]
 
 
 class Task(BaseModel):

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -94,6 +94,17 @@ class Settings(BaseSettings):
     max_tries: int = 20
     """Maximum attempts to write to DynamoDB table."""
 
+    publish_timeout: int = 24
+    """Maximum amount of time (in hours) between updates to a pending publish before
+    it will be considered abandoned. Defaults to one day.
+    """
+
+    history_timeout: int = 24 * 14
+    """Maximum amount of time (in hours) to retain historical data for publishes and
+    tasks. Publishes and tasks in a terminal state will be erased after this time has
+    passed. Defaults to two weeks.
+    """
+
     actor_time_limit: int = 30 * 60000
     """Maximum amount of time (in milliseconds) actors may run."""
 

--- a/exodus_gw/worker/scheduled.py
+++ b/exodus_gw/worker/scheduled.py
@@ -1,16 +1,104 @@
 import logging
+from datetime import datetime, timedelta, timezone
 
 import dramatiq
+from sqlalchemy.orm import Session
+
+from exodus_gw.database import db_engine
+from exodus_gw.models import Publish, Task
+from exodus_gw.schemas import PublishStates, TaskStates
+from exodus_gw.settings import Settings
 
 LOG = logging.getLogger("exodus-gw")
 
 
+class Janitor:
+    def __init__(self):
+        self.settings = Settings()
+        self.db = Session(bind=db_engine(self.settings))
+        self.now = datetime.now(timezone.utc)
+
+    def run(self):
+        self.fix_timestamps()
+        self.fix_abandoned()
+        self.clean_old_data()
+
+        self.db.commit()
+
+        LOG.info("Scheduled cleanup has completed")
+
+    def fix_timestamps(self):
+        # Fill in missing timestamps on any data.
+        #
+        # Timestamps are nullable. If we aren't sure the real
+        # updated timestamp on a particular object, we'll just
+        # pretend it was updated right now.
+        for klass in [Task, Publish]:
+            for instance in self.db.query(klass).filter(klass.updated == None):
+                LOG.warning(
+                    "%s %s: setting updated",
+                    klass.__name__,
+                    instance.id,
+                )
+                instance.updated = self.now
+
+    def fix_abandoned(self):
+        # Find any publishes and tasks which appear to be abandoned (i.e.
+        # they did not complete and have not been updated for a long time)
+        # and mark them as failed.
+        #
+        # This covers scenarios:
+        #
+        # - a client created a publish, then crashed before committing it.
+        #
+        # - an internal error in exodus-gw somehow prevented a task from being
+        #   executed and also prevented marking the task as failed, such as
+        #   an extended outage from the DB.
+        #
+        hours = self.settings.publish_timeout
+        threshold = self.now - timedelta(hours=hours)
+
+        for klass, states in [(Task, TaskStates), (Publish, PublishStates)]:
+            for instance in self.db.query(klass).filter(
+                # Anything old enough...
+                klass.updated < threshold,
+                # And also not in a terminal state...
+                ~klass.state.in_(states.terminal()),
+            ):
+                LOG.warning(
+                    "%s %s: marking as failed (last updated: %s)",
+                    klass.__name__,
+                    instance.id,
+                    instance.updated,
+                )
+                instance.state = states.failed
+
+    def clean_old_data(self):
+        # Find any objects of transient types in terminal states which have not
+        # been updated for the configured period of time and delete them.
+        #
+        # This helps enforce the design that exodus-gw contains no persistent
+        # state.
+        hours = self.settings.history_timeout
+        threshold = self.now - timedelta(hours=hours)
+
+        for klass, states in [(Task, TaskStates), (Publish, PublishStates)]:
+            for instance in self.db.query(klass).filter(
+                # Anything old enough...
+                klass.updated < threshold,
+                # And also in a terminal state so there will be no further updates...
+                klass.state.in_(states.terminal()),
+            ):
+                LOG.info(
+                    "%s %s: cleaning old data (last updated: %s)",
+                    klass.__name__,
+                    instance.id,
+                    instance.updated,
+                )
+                self.db.delete(instance)
+
+
 @dramatiq.actor(scheduled=True)
 def cleanup():
-    # TODO: implement me.
-    #
-    # We must first implement:
-    # - timestamps on task and publish objects
-    # - state on publish objects
-    #
-    LOG.warning("Would do cleanup now")
+    janitor = Janitor()
+    janitor.run()

--- a/tests/dramatiq/test_scheduler.py
+++ b/tests/dramatiq/test_scheduler.py
@@ -4,10 +4,8 @@ from unittest import mock
 
 import dramatiq
 import pytest
-from fastapi.testclient import TestClient
 
 from exodus_gw.dramatiq import Broker
-from exodus_gw.main import app
 from exodus_gw.models import DramatiqMessage
 from exodus_gw.settings import Settings
 
@@ -26,7 +24,7 @@ def mock_utcnow():
         yield mock_datetime.utcnow
 
 
-def test_scheduled_actor_invoked_on_rule_match(mock_utcnow):
+def test_scheduled_actor_invoked_on_rule_match(db, mock_utcnow):
     """Scheduled actors only get invoked when cron rule from settings is matched."""
 
     settings = ExtendedSettings()
@@ -39,39 +37,38 @@ def test_scheduled_actor_invoked_on_rule_match(mock_utcnow):
     def schedule_test1():
         calls.append(True)
 
-    with TestClient(app):
-        now = datetime(1999, 1, 1)
-        mock_utcnow.return_value = now
+    now = datetime(1999, 1, 1)
+    mock_utcnow.return_value = now
 
-        # First call does not match the cron rule
-        schedule_test1.fn()
+    # First call does not match the cron rule
+    schedule_test1.fn()
 
-        # So it shouldn't trigger the underlying actor
-        assert not calls
+    # So it shouldn't trigger the underlying actor
+    assert not calls
 
-        # Set time to 1:07, just after 1:05 hitting the cron rule
-        now = now.replace(hour=1, minute=7)
-        mock_utcnow.return_value = now
+    # Set time to 1:07, just after 1:05 hitting the cron rule
+    now = now.replace(hour=1, minute=7)
+    mock_utcnow.return_value = now
 
-        # Now it should hit the rule if looking back a few minutes
-        schedule_test1.fn(now.timestamp() - 120.0)
-        assert len(calls) == 1
+    # Now it should hit the rule if looking back a few minutes
+    schedule_test1.fn(now.timestamp() - 120.0)
+    assert len(calls) == 1
 
-        # While looking back 30 seconds should not
-        schedule_test1.fn(now.timestamp() - 30.0)
-        assert len(calls) == 1
+    # While looking back 30 seconds should not
+    schedule_test1.fn(now.timestamp() - 30.0)
+    assert len(calls) == 1
 
-        # Same at 3:07
-        now = now.replace(hour=3)
-        mock_utcnow.return_value = now
-        schedule_test1.fn(now.timestamp() - 120.0)
-        assert len(calls) == 2
+    # Same at 3:07
+    now = now.replace(hour=3)
+    mock_utcnow.return_value = now
+    schedule_test1.fn(now.timestamp() - 120.0)
+    assert len(calls) == 2
 
-        # But no match at 4:07
-        now = now.replace(hour=4)
-        mock_utcnow.return_value = now
-        schedule_test1.fn(now.timestamp() - 120.0)
-        assert len(calls) == 2
+    # But no match at 4:07
+    now = now.replace(hour=4)
+    mock_utcnow.return_value = now
+    schedule_test1.fn(now.timestamp() - 120.0)
+    assert len(calls) == 2
 
 
 def test_scheduled_actor_enqueued_on_startup(db):
@@ -90,76 +87,75 @@ def test_scheduled_actor_enqueued_on_startup(db):
     def schedule_test2():
         pass
 
-    with TestClient(app):
-        # Simulate that some messages already exist when
-        # broker starts up.
-        db.add(
-            DramatiqMessage(
-                id=uuid.uuid4(),
-                queue="default",
-                actor="schedule_test1",
-                body={},
-            )
+    # Simulate that some messages already exist when
+    # broker starts up.
+    db.add(
+        DramatiqMessage(
+            id=uuid.uuid4(),
+            queue="default",
+            actor="schedule_test1",
+            body={},
         )
-        db.add(
-            DramatiqMessage(
-                id=uuid.uuid4(),
-                queue="default",
-                actor="schedule_test1",
-                body={},
-            )
+    )
+    db.add(
+        DramatiqMessage(
+            id=uuid.uuid4(),
+            queue="default",
+            actor="schedule_test1",
+            body={},
         )
-        db.add(
-            DramatiqMessage(
-                id=uuid.uuid4(),
-                queue="default",
-                actor="schedule_test2",
-                body={},
-            )
+    )
+    db.add(
+        DramatiqMessage(
+            id=uuid.uuid4(),
+            queue="default",
+            actor="schedule_test2",
+            body={},
         )
+    )
 
-        # There can be messages for unrelated actors too.
-        db.add(
-            DramatiqMessage(
-                id=uuid.UUID("f3d9ae4aeea6946a8668445395ba10b7"),
-                queue="default",
-                actor="other_actor",
-                body={},
-            )
+    # There can be messages for unrelated actors too.
+    db.add(
+        DramatiqMessage(
+            id=uuid.UUID("f3d9ae4aeea6946a8668445395ba10b7"),
+            queue="default",
+            actor="other_actor",
+            body={},
         )
+    )
 
-        db.commit()
+    db.commit()
 
-        # Boot up the broker.
-        broker.emit_after("process_boot")
+    # Boot up the broker.
+    broker.emit_after("process_boot")
 
-        # Now check DB state:
-        db.expire_all()
-        db_messages = sorted(
-            db.query(DramatiqMessage).all(), key=lambda msg: msg.actor
-        )
+    # Now check DB state:
+    db.expire_all()
+    db_messages = sorted(
+        db.query(DramatiqMessage).all(), key=lambda msg: msg.actor
+    )
 
-        raw_messages = [(str(m.id), m.queue, m.actor) for m in db_messages]
+    raw_messages = [(str(m.id), m.queue, m.actor) for m in db_messages]
 
-        # During boot, it should clean existing scheduled messages and
-        # ensure exactly one message per scheduled actor, leaving us with
-        # three messages:
-        assert raw_messages == [
-            # The message unrelated to scheduler is left untouched
-            ("f3d9ae4a-eea6-946a-8668-445395ba10b7", "default", "other_actor"),
-            # Then one message per scheduled actor.
-            # Note: messages go to delayed queue (DQ) since they are delayed messages.
-            # Note: it is correct that UUIDs are hardcoded here even though random
-            # ones were used above. The system uses a fixed UUID for the initial
-            # message per scheduled actor.
-            (
-                "b343626c-8d3a-50b3-9624-f18e61020dce",
-                "default.DQ",
-                "schedule_test1",
-            ),
-            (
-                "dbe98881-cac5-5446-9dd9-1912cae1c71c",
-                "default.DQ",
-                "schedule_test2",
-            ),
-        ]
+    # During boot, it should clean existing scheduled messages and
+    # ensure exactly one message per scheduled actor, leaving us with
+    # three messages:
+    assert raw_messages == [
+        # The message unrelated to scheduler is left untouched
+        ("f3d9ae4a-eea6-946a-8668-445395ba10b7", "default", "other_actor"),
+        # Then one message per scheduled actor.
+        # Note: messages go to delayed queue (DQ) since they are delayed messages.
+        # Note: it is correct that UUIDs are hardcoded here even though random
+        # ones were used above. The system uses a fixed UUID for the initial
+        # message per scheduled actor.
+        (
+            "b343626c-8d3a-50b3-9624-f18e61020dce",
+            "default.DQ",
+            "schedule_test1",
+        ),
+        (
+            "dbe98881-cac5-5446-9dd9-1912cae1c71c",
+            "default.DQ",
+            "schedule_test2",
+        ),
+    ]

--- a/tests/migrate/test_db_migrate.py
+++ b/tests/migrate/test_db_migrate.py
@@ -7,41 +7,44 @@ from exodus_gw.models import Publish
 from exodus_gw.settings import MigrationMode, Settings
 
 
-def test_db_migrate_typical(db):
+def test_db_migrate_typical(unmigrated_db):
     # Sanity check: at first there's no tables
     with pytest.raises(OperationalError):
-        db.query(Publish).count()
+        unmigrated_db.query(Publish).count()
 
     # Migrate should succeed
-    db_migrate(db.get_bind(), Settings())
+    db_migrate(unmigrated_db.get_bind(), Settings())
 
     # Now we can query stuff
-    assert db.query(Publish).count() == 0
+    assert unmigrated_db.query(Publish).count() == 0
 
 
-def test_db_migrate_reset(db):
+def test_db_migrate_reset(unmigrated_db):
     # First ensure there's some tables
-    db_migrate(db.get_bind(), Settings())
-    assert db.query(Publish).count() == 0
+    db_migrate(unmigrated_db.get_bind(), Settings())
+    assert unmigrated_db.query(Publish).count() == 0
 
     # Now if we request a reset with no migration afterward...
     db_migrate(
-        db.get_bind(),
+        unmigrated_db.get_bind(),
         Settings(db_reset=True, db_migration_mode=MigrationMode.none),
     )
 
     # ... then there should be nothing
     with pytest.raises(OperationalError):
-        db.query(Publish).count()
+        unmigrated_db.query(Publish).count()
 
 
-def test_db_migrate_model(db):
+def test_db_migrate_model(unmigrated_db):
     # Sanity check: at first there's no tables
     with pytest.raises(OperationalError):
-        db.query(Publish).count()
+        unmigrated_db.query(Publish).count()
 
     # Migrate using model should succeed
-    db_migrate(db.get_bind(), Settings(db_migration_mode=MigrationMode.model))
+    db_migrate(
+        unmigrated_db.get_bind(),
+        Settings(db_migration_mode=MigrationMode.model),
+    )
 
     # Now we can query stuff
-    assert db.query(Publish).count() == 0
+    assert unmigrated_db.query(Publish).count() == 0

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -184,9 +184,8 @@ def test_update_pubish_items_invalid_publish(db):
 def test_commit_publish(mock_commit, fake_publish, db):
     """Ensure commit_publish delegates to worker correctly and creates task."""
 
-    with TestClient(app):
-        db.add(fake_publish)
-        db.commit()
+    db.add(fake_publish)
+    db.commit()
 
     publish_task = routers.publish.commit_publish(
         env=get_environment("test"),
@@ -212,11 +211,10 @@ def test_commit_publish(mock_commit, fake_publish, db):
 def test_commit_publish_prev_completed(mock_commit, fake_publish, db):
     """Ensure commit_publish fails for publishes in invalid state."""
 
-    with TestClient(app):
-        db.add(fake_publish)
-        # Simulate that this publish was published.
-        fake_publish.state = schemas.PublishStates.committed
-        db.commit()
+    db.add(fake_publish)
+    # Simulate that this publish was published.
+    fake_publish.state = schemas.PublishStates.committed
+    db.commit()
 
     with pytest.raises(HTTPException) as exc_info:
         routers.publish.commit_publish(

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -70,7 +70,6 @@ def test_get_task(db):
         state="NOT_STARTED",
     )
 
-    # Use TestClient to set up the test DB.
     with TestClient(app) as client:
         # Add a task object to the DB.
         db.add(task)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,6 @@
 import uuid
 from datetime import datetime
 
-from fastapi.testclient import TestClient
-
-from exodus_gw.main import app
 from exodus_gw.models import Item, Publish, Task
 
 
@@ -31,35 +28,34 @@ def test_publish_task_before_update(db):
         state="NOT_STARTED",
     )
 
-    with TestClient(app):
-        db.add(publish)
-        db.add(task)
-        db.commit()
+    db.add(publish)
+    db.add(task)
+    db.commit()
 
-        # Updated should initially be null
-        assert publish.updated is None
-        assert task.updated is None
+    # Updated should initially be null
+    assert publish.updated is None
+    assert task.updated is None
 
-        # Change state of publish and task
-        publish.state = "COMMITTING"
-        task.state = "IN_PROGRESS"
-        db.commit()
+    # Change state of publish and task
+    publish.state = "COMMITTING"
+    task.state = "IN_PROGRESS"
+    db.commit()
 
-        # Updated should now hold datetime objects
-        p_updated = publish.updated
-        assert isinstance(p_updated, datetime)
+    # Updated should now hold datetime objects
+    p_updated = publish.updated
+    assert isinstance(p_updated, datetime)
 
-        t_updated = task.updated
-        assert isinstance(t_updated, datetime)
+    t_updated = task.updated
+    assert isinstance(t_updated, datetime)
 
-        # Change state of publish and task again
-        publish.state = "COMMITTED"
-        task.state = "COMPLETE"
-        db.commit()
+    # Change state of publish and task again
+    publish.state = "COMMITTED"
+    task.state = "COMPLETE"
+    db.commit()
 
-        # Updated should now hold different datetime objects
-        assert isinstance(publish.updated, datetime)
-        assert p_updated != publish.updated
+    # Updated should now hold different datetime objects
+    assert isinstance(publish.updated, datetime)
+    assert p_updated != publish.updated
 
-        assert isinstance(task.updated, datetime)
-        assert t_updated != task.updated
+    assert isinstance(task.updated, datetime)
+    assert t_updated != task.updated

--- a/tests/worker/test_cleanup.py
+++ b/tests/worker/test_cleanup.py
@@ -1,3 +1,12 @@
+import logging
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm.exc import ObjectDeletedError
+
+from exodus_gw.models import Item, Publish, Task
+from exodus_gw.schemas import PublishStates, TaskStates
 from exodus_gw.worker import cleanup
 
 # cleanup is a scheduled actor, we want to test the actor itself
@@ -7,9 +16,190 @@ from exodus_gw.worker import cleanup
 cleanup = cleanup.options["unscheduled_fn"]
 
 
-def test_cleanup_noop():
-    """Calling cleanup doesn't crash."""
+def test_cleanup_noop(caplog, db):
+    """Cleanup with no data to clean does nothing, successfully."""
 
-    # Actual implementation doesn't exist yet so we don't have
-    # any more meaningful test right now.
+    logging.getLogger("exodus-gw").setLevel(logging.INFO)
+
+    # Should run
     cleanup()
+
+    # It should not have done anything, other than log this.
+    assert caplog.messages == ["Scheduled cleanup has completed"]
+
+
+def test_cleanup_mixed(caplog, db):
+    """Cleanup manipulates objects in the expected manner."""
+
+    logging.getLogger("exodus-gw").setLevel(logging.INFO)
+
+    # Note: datetimes in this test assume the default timeout values
+    # are used.
+
+    now = datetime.utcnow()
+    half_day_ago = now - timedelta(hours=12)
+    two_days_ago = now - timedelta(days=2)
+    eight_days_ago = now - timedelta(days=8)
+    twenty_days_ago = now - timedelta(days=30)
+
+    # Some objects with missing timestamps.
+    p1_missing_ts = Publish(
+        id=uuid.uuid4(), env="test", state=PublishStates.failed, updated=None
+    )
+    p2_missing_ts = Publish(
+        id=uuid.uuid4(),
+        env="test2",
+        state=PublishStates.committed,
+        updated=None,
+    )
+    t1_missing_ts = Task(
+        id=uuid.uuid4(),
+        publish_id=p1_missing_ts.id,
+        state=TaskStates.failed,
+        updated=None,
+    )
+
+    # Some publishes which seem to be abandoned.
+    p1_abandoned = Publish(
+        id=uuid.uuid4(),
+        env="test",
+        state=PublishStates.pending,
+        updated=eight_days_ago,
+        items=[
+            Item(web_uri="/1", object_key="abc"),
+            Item(web_uri="/2", object_key="aabbcc"),
+        ],
+    )
+    p2_abandoned = Publish(
+        id=uuid.uuid4(),
+        env="test",
+        state=PublishStates.committing,
+        updated=twenty_days_ago,
+    )
+    t1_abandoned = Task(
+        id=uuid.uuid4(),
+        publish_id=p1_abandoned.id,
+        state=TaskStates.in_progress,
+        updated=eight_days_ago,
+    )
+
+    # Some objects which are old enough to be cleaned up.
+    p1_old = Publish(
+        id=uuid.uuid4(),
+        env="test2",
+        state=PublishStates.committed,
+        updated=twenty_days_ago,
+        items=[
+            Item(web_uri="/1", object_key="abc"),
+            Item(web_uri="/2", object_key="aabbcc"),
+        ],
+    )
+    p2_old = Publish(
+        id=uuid.uuid4(),
+        env="test3",
+        state=PublishStates.failed,
+        updated=twenty_days_ago,
+    )
+    t1_old = Task(
+        id=uuid.uuid4(),
+        publish_id=p1_old.id,
+        state=TaskStates.failed,
+        updated=twenty_days_ago,
+    )
+    # (Because these objects will be deleted, we need to keep their ids separately.)
+    p1_old_id = p1_old.id
+    p2_old_id = p2_old.id
+    t1_old_id = t1_old.id
+
+    # And finally some recent objects which should not be touched at all.
+    p1_recent = Publish(
+        id=uuid.uuid4(),
+        env="test3",
+        state=PublishStates.pending,
+        updated=half_day_ago,
+    )
+    t1_recent = Task(
+        id=uuid.uuid4(),
+        publish_id=p1_recent.id,
+        state=TaskStates.complete,
+        updated=two_days_ago,
+    )
+
+    # self.fix_abandoned_publishes()
+    # self.clean_old_data()
+
+    db.add_all(
+        [
+            p1_missing_ts,
+            p2_missing_ts,
+            t1_missing_ts,
+            p1_abandoned,
+            p2_abandoned,
+            t1_abandoned,
+            p1_old,
+            p2_old,
+            t1_old,
+            p1_recent,
+            t1_recent,
+        ]
+    )
+    db.commit()
+
+    # Should run successfully
+    cleanup()
+
+    # Make sure we reload anything which has changed
+    db.expire_all()
+
+    # Missing timestamps should now be filled in (fuzzy comparison as exact
+    # time is not set)
+    assert (t1_missing_ts.updated - now) < timedelta(seconds=10)
+    assert (p1_missing_ts.updated - now) < timedelta(seconds=10)
+    assert (p2_missing_ts.updated - now) < timedelta(seconds=10)
+
+    # The abandoned objects should now be marked as failed
+    assert p1_abandoned.state == PublishStates.failed
+    assert p2_abandoned.state == PublishStates.failed
+    assert t1_abandoned.state == TaskStates.failed
+
+    # The old objects should no longer exist.
+    with pytest.raises(ObjectDeletedError):
+        p1_old.id
+    with pytest.raises(ObjectDeletedError):
+        p2_old.id
+    with pytest.raises(ObjectDeletedError):
+        t1_old.id
+
+    # Other objects should still exist as they were.
+    assert p1_recent.state == PublishStates.pending
+    assert t1_recent.state == TaskStates.complete
+
+    # It should have logged exactly what it did.
+    assert sorted(caplog.messages) == sorted(
+        [
+            ####################################################
+            # Fixed timestamps
+            "Task %s: setting updated" % (t1_missing_ts.id,),
+            "Publish %s: setting updated" % (p1_missing_ts.id,),
+            "Publish %s: setting updated" % (p2_missing_ts.id,),
+            ####################################################
+            # Abandoned objects
+            "Task %s: marking as failed (last updated: %s)"
+            % (t1_abandoned.id, eight_days_ago),
+            "Publish %s: marking as failed (last updated: %s)"
+            % (p1_abandoned.id, eight_days_ago),
+            "Publish %s: marking as failed (last updated: %s)"
+            % (p2_abandoned.id, twenty_days_ago),
+            ####################################################
+            # Deleted old stuff
+            "Task %s: cleaning old data (last updated: %s)"
+            % (t1_old_id, twenty_days_ago),
+            "Publish %s: cleaning old data (last updated: %s)"
+            % (p1_old_id, twenty_days_ago),
+            "Publish %s: cleaning old data (last updated: %s)"
+            % (p2_old_id, twenty_days_ago),
+            ####################################################
+            # Completed cleanup
+            "Scheduled cleanup has completed",
+        ]
+    )


### PR DESCRIPTION
Previously we had a stubbed out scheduled cleanup task, as we
needed some more columns on the model before it could be
implemented.

As those are now available, let's fill in the implementation of
the cleanup task. It covers steps:

- find & fix anything with missing timestamps
- mark anything which is obviously abandoned or stuck as failed
  (for 2 days by default)
- delete anything which has been in a terminal state for long
  enough (2 weeks by default)

The thresholds are configurable via settings.