### PR TITLE
Require authorization for upload and publish APIs [RHELDST-4729]

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -78,10 +78,14 @@ def needs_role(rolename):
     >    "If caller does not have role xyz, they will never get here."
     """
 
-    async def check_roles(roles: Set[str] = Depends(caller_roles)):
-        if rolename not in roles:
+    async def check_roles(
+        env: Optional[str] = None, roles: Set[str] = Depends(caller_roles)
+    ):
+        role = env + "-" + rolename if env else rolename
+
+        if role not in roles:
             raise HTTPException(
-                403, "this operation requires role '%s'" % rolename
+                403, "this operation requires role '%s'" % role
             )
 
     return Depends(check_roles)

--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -37,6 +37,14 @@ com.redhat.api.platform:\n\
 |\n$(sed -r -e 's|^|    |' %S/exodus-gw-dev/service.pem)\n\
   private-key-pkcs8-pem:\
 |\n$(sed -r -e 's|^|    |' %S/exodus-gw-dev/service-key.pem)\n\
+ security:\n\
+  roles:\n\
+   test-blob-uploader:\n\
+    users:\n\
+     byInternalUsername: [${USER}]\n\
+   test-publisher:\n\
+    users:\n\
+     byInternalUsername: [${USER}]\n\
 \nEND\n\
 "
 

--- a/scripts/systemd/install
+++ b/scripts/systemd/install
@@ -66,6 +66,12 @@ EXODUS_GW_SRC_PATH=$(realpath -L ../..)
 
 # You'll have to change this too if you change the localstack port.
 #EXODUS_GW_S3_ENDPOINT_URL=https://localhost:3377
+
+# Disable migrations during development
+#EXODUS_GW_DB_MIGRATION_MODE=model
+
+# Drop and recreate tables on restart
+#EXODUS_GW_DB_RESET=true
 END
   fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,15 @@
+import base64
+import json
 import os
 import uuid
+from typing import List
 
 import mock
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm.session import Session
 
-from exodus_gw import database, main, models, schemas, settings  # noqa
+from exodus_gw import auth, database, main, models, schemas, settings  # noqa
 
 from .async_utils import BlockDetector
 
@@ -139,3 +142,22 @@ def fake_publish():
         ),
     ]
     yield publish
+
+
+@pytest.fixture
+def auth_header():
+    def _auth_header(roles: List[str] = []):
+        raw_context = {
+            "user": {
+                "authenticated": True,
+                "internalUsername": "fake-user",
+                "roles": roles,
+            }
+        }
+
+        json_context = json.dumps(raw_context).encode("utf-8")
+        b64_context = base64.b64encode(json_context)
+
+        return {"X-RhApiPlatform-CallContext": b64_context.decode("utf-8")}
+
+    return _auth_header


### PR DESCRIPTION
Users must now possess the appropriate role to request uploads or
publishes to a particular environment, e.g., "stage-blob-uploader" to
upload to the "stage" environment.

The development environment was updated to automatically authorizate
users for the "test" environment.