### PR TITLE
docs: tweak API docs for "HEAD object"

### DIFF
--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -319,8 +319,12 @@ async def abort_multipart_upload(
 
 @router.head(
     "/upload/{env}/{key}",
-    summary="Request head object",
+    summary="Get object metadata",
     response_class=Response,
+    responses={
+        200: {"description": "Object exists"},
+        404: {"description": "Object or environment does not exist"},
+    },
     dependencies=[auth.needs_role("blob-uploader")],
 )
 async def head(
@@ -328,6 +332,11 @@ async def head(
     key: str = Path(..., description="S3 object key"),
 ):
     """Retrieve metadata from an S3 object.
+
+    Note that, as explained in [the upload API overview](#tag/upload), AWS-specific
+    headers such as `x-amz-*` are not included in the response.
+    The main purpose of this API is to determine whether or not an object
+    identified by checksum exists on the CDN.
 
     **Required roles**: `{env}-blob-uploader`
     """


### PR DESCRIPTION
- change name from "Request head object" to "Get object metadata" to
  fit more closely with names for other endpoints

- fill a bit more in the description of this API, explaining that
  the main purpose is to test whether an object exists, which might
  not be obvious

- fill in response descriptions to make it clear that a 404 response
  is the expected way for the service to communicate that an object
  doesn't exist