### PR TITLE
Replace push-docs' GITHUB_TOKEN with access token [RHELDST-5390]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   pull_request:
@@ -45,5 +45,5 @@ jobs:
     - name: Publish documentation
       if: ${{ success() }}
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
       run: scripts/push-docs


### PR DESCRIPTION
The push-docs script, when passed 'github.token', reports "No
such device or address". This commit replaces the token with a personal
access token, which was the method used with Travis.ci.