### PR TITLE
Fix push-docs failing when docs haven't changed

### DIFF
--- a/scripts/push-docs
+++ b/scripts/push-docs
@@ -30,6 +30,13 @@ if enabled; then
 fi
 
 git add -A .
+
+if git diff --cached --quiet; then
+  # zero exit from git diff means nothing changed.
+  echo "No changes to docs, bailing out"
+  exit 0
+fi
+
 git commit -m "Build documentation for ${version} at ${rev}"
 
 if enabled; then


### PR DESCRIPTION
Since we moved from Travis to Actions, the push-docs step started
to fail after merging if docs haven't changed since last push.

The behavior of the script didn't change, but it seems that Travis
simply ignored the exit code of an "after_success" command since
the job had already succeeded by that point. Actions works a bit
different and it's important to exit with a 0 exit code in this
case.