### PR TITLE
Return to coveralls-python for reporting coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,9 @@ jobs:
         docker build . -f openshift/containers/exodus-gw/Dockerfile
 
     - name: Run auto-tests
-      run: tox -e cov
-
-    - name: Publish coverage
-      uses: AndreMiras/coveralls-python-action@develop
-      with:
-        github-token: ${{ github.token }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: tox -e cov-ci
 
     - name: Run static analysis
       run: tox -e static

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,13 @@ usedevelop=true
 commands=
 	pytest --cov-report=html --cov=exodus_gw {posargs}
 
+[testenv:cov-ci]
+passenv=GITHUB_*
+usedevelop=true
+commands=
+	pytest --cov=exodus_gw {posargs}
+	coveralls --service=github
+
 [testenv:docs]
 use_develop=true
 commands=


### PR DESCRIPTION
When switching to Github actions from Travis CI, the method of
publishing coverage data to coveralls changed from using
coveralls-python package to a Github action.

This commit reverses that switch, returning to coveralls-python for
reporting coverage, as the Github action alternative has demonstrated
inaccurate reporting in another project.