### PR TITLE
Drop dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: /
-  schedule:
-    interval: weekly
-  allow:
-  - dependency-type: all


### PR DESCRIPTION
We're trying a new "scheduled pip-compile" workflow rather than
dependabot, see recently introduced workflow files.