### PR TITLE
Fix CI issues with scheduled pip-compile

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -22,11 +22,11 @@ jobs:
          EXECUTE_COMMANDS: |
            pip install pip-tools
            pip-compile -U --generate-hashes requirements.in
-           pip-compile -U --generate-hashes test-requirements.in
-           
+           pip-compile -U --generate-hashes requirements.in test-requirements.in -o test-requirements.txt
          COMMIT_MESSAGE: 'chore: scheduled pip-compile'
          COMMIT_NAME: 'GitHub Actions'
          COMMIT_EMAIL: 'noreply@github.com'
+         GITHUB_TOKEN: ${{ secrets.PIP_COMPILE_TOKEN }}
          PR_BRANCH_PREFIX: deps/
          PR_BRANCH_NAME: 'pip-compile'
          PR_TITLE: 'chore: scheduled pip-compile'


### PR DESCRIPTION
Addresses the following issues in scheduled pip-compile (see also https://github.com/release-engineering/exodus-gw/commit/ce0e58a1a2a5d9976f0ef2e193de09c1ee58d94e for more explanation):

- when compiling test-requirements.txt, we really need to use both requirements.in and test-requirements.in together.  It's needed to ensure that the generated requirements end up being compatible with *both* of the inputs.
- we need to use a non-default token when creating the PR.  If not, it runs into the rule from https://docs.github.com/en/actions/reference/events-that-trigger-workflows: "When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run".  That means, if the repo's CI is based on actions (as it is here), then CI will never run over the pull request.
    - we now use a token associated with @cd-red-bot .