### PR TITLE
Accept publish items with link_to or object_key [RHELDST-8586]

### DIFF
--- a/exodus_gw/migrations/versions/c46641b76073_.py
+++ b/exodus_gw/migrations/versions/c46641b76073_.py
@@ -1,0 +1,46 @@
+"""Add link_to column to items table and make it and object_key nullable
+
+Revision ID: c46641b76073
+Revises: 55d4111a0e09
+Create Date: 2021-11-03 13:00:30.443526
+
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c46641b76073"
+down_revision = "55d4111a0e09"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # clean all items first to avoid crashing on null actor
+    op.execute("DELETE FROM items")
+
+    # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
+    # on sqlite < 3.32.0
+    recreate = (
+        "always"
+        if "sqlite" in os.environ.get("EXODUS_GW_DB_URL", "")
+        else "auto"
+    )
+
+    with op.batch_alter_table("items", recreate=recreate) as batch_op:
+        batch_op.add_column(sa.Column("link_to", sa.String(), nullable=True))
+        batch_op.alter_column(
+            "object_key", existing_type=sa.VARCHAR(), nullable=True
+        )
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    with op.batch_alter_table("items") as batch_op:
+        batch_op.alter_column(
+            "object_key", existing_type=sa.VARCHAR(), nullable=False
+        )
+        batch_op.drop_column("link_to")
+    # ### end Alembic commands ###

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -40,7 +40,8 @@ class Item(Base):
         default=uuid.uuid4,
     )
     web_uri = Column(String, nullable=False)
-    object_key = Column(String, nullable=False)
+    object_key = Column(String, nullable=True)
+    link_to = Column(String, nullable=True)
     publish_id = Column(
         UUID(as_uuid=True), ForeignKey("publishes.id"), nullable=False
     )

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -24,12 +24,13 @@ class ItemBase(BaseModel):
         description="URI, relative to CDN root, which shall be used to expose this object.",
     )
     object_key: str = Field(
-        ...,
+        "",
         description=(
             "Key of blob to be exposed; should be the SHA256 checksum of a previously uploaded "
             "piece of content, in lowercase hex-digest form."
         ),
     )
+    link_to: str = Field("", description="Path of file targeted by symlink.")
 
 
 class Item(ItemBase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ def test_Item_init():
     item = Item(
         web_uri="/some/path",
         object_key="abcde",
+        link_to="",
         publish_id="123e4567-e89b-12d3-a456-426614174000",
     )
     assert item.web_uri == "/some/path"

--- a/tests/worker/test_cleanup.py
+++ b/tests/worker/test_cleanup.py
@@ -66,8 +66,8 @@ def test_cleanup_mixed(caplog, db):
         state=PublishStates.pending,
         updated=eight_days_ago,
         items=[
-            Item(web_uri="/1", object_key="abc"),
-            Item(web_uri="/2", object_key="aabbcc"),
+            Item(web_uri="/1", object_key="abc", link_to=""),
+            Item(web_uri="/2", object_key="aabbcc", link_to=""),
         ],
     )
     p2_abandoned = Publish(
@@ -90,8 +90,8 @@ def test_cleanup_mixed(caplog, db):
         state=PublishStates.committed,
         updated=twenty_days_ago,
         items=[
-            Item(web_uri="/1", object_key="abc"),
-            Item(web_uri="/2", object_key="aabbcc"),
+            Item(web_uri="/1", object_key="abc", link_to=""),
+            Item(web_uri="/2", object_key="aabbcc", link_to=""),
         ],
     )
     p2_old = Publish(


### PR DESCRIPTION
Previously, exodus-gw accepted items that had a web_uri and a valid
object_key. Soon exodus-rsync will send items with a link_to value
instead of an object_key and the resolution of the object_key will be
handled within exodus-gw based on the link_to path. With this commit
exodus-gw accepts items that have either a link_to or an object_key.