### PR TITLE
Resolve item object_keys from link_to [RHELDST-8587]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
+from fastapi import HTTPException
 from sqlalchemy import Column, DateTime, ForeignKey, String, event
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
@@ -23,6 +24,28 @@ class Publish(Base):
     items = relationship(
         "Item", back_populates="publish", cascade="all, delete-orphan"
     )
+
+    def resolve_links(self):
+        ok_items = []
+        ln_items = []
+        for item in self.items:
+            if item.object_key:
+                ok_items.append(item)
+            else:
+                ln_items.append(item)
+
+        for ln_item in ln_items:
+            matched = [i for i in ok_items if i.web_uri == ln_item.link_to]
+            if not matched:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Unable to resolve item object_key:"
+                        "\n\tURI: '%s'\n\tLink: '%s'"
+                    )
+                    % (ln_item.web_uri, ln_item.link_to),
+                )
+            ln_item.object_key = matched[0].object_key
 
 
 @event.listens_for(Publish, "before_update")

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -26,17 +26,17 @@ class Publish(Base):
     )
 
     def resolve_links(self):
-        ok_items = []
+        ok_items = {}
         ln_items = []
         for item in self.items:
             if item.object_key:
-                ok_items.append(item)
+                ok_items[item.web_uri] = [item.object_key]
             else:
                 ln_items.append(item)
 
         for ln_item in ln_items:
-            matched = [i for i in ok_items if i.web_uri == ln_item.link_to]
-            if not matched:
+            ln_item.object_key = ok_items[ln_item.link_to]
+            if not ln_item.object_key:
                 raise HTTPException(
                     status_code=400,
                     detail=(
@@ -45,7 +45,6 @@ class Publish(Base):
                     )
                     % (ln_item.web_uri, ln_item.link_to),
                 )
-            ln_item.object_key = matched[0].object_key
 
 
 @event.listens_for(Publish, "before_update")

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -35,7 +35,7 @@ class Publish(Base):
                 ln_items.append(item)
 
         for ln_item in ln_items:
-            ln_item.object_key = ok_items[ln_item.link_to]
+            ln_item.object_key = ok_items.get(ln_item.link_to)
             if not ln_item.object_key:
                 raise HTTPException(
                     status_code=400,

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -30,7 +30,7 @@ class Publish(Base):
         ln_items = []
         for item in self.items:
             if item.object_key:
-                ok_items[item.web_uri] = [item.object_key]
+                ok_items[item.web_uri] = item.object_key
             else:
                 ln_items.append(item)
 

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -242,6 +242,8 @@ def commit_publish(
             % (db_publish.id, db_publish.state),
         )
 
+    db_publish.resolve_links()
+
     msg = worker.commit.send(
         publish_id=str(db_publish.id),
         env=env.name,


### PR DESCRIPTION
Now that items with either object_key or link_to are accepted,
we can use link_to to find the correct object_key from among the other
publish items.

This commit adds the resolve_links function to the publish model.
If the function doesn't find an item with a web_uri that maches the
link_to of the target item, an error of code 400 is raised.