### PR TITLE
Resolve origin aliases before publishing [RHELDST-8582]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -128,4 +128,6 @@ disable=print-statement,
         # It's sometimes reasonable to handle any Exception without checking it
         broad-except,
         # no immediate need to refactor every string
-        consider-using-f-string
+        consider-using-f-string,
+        # it's resonable to have more than five (5) arguments
+        too-many-arguments,

--- a/exodus-gw.ini
+++ b/exodus-gw.ini
@@ -2,16 +2,19 @@
 aws_profile = test
 bucket = my-bucket
 table = my-table
+config_table = my-config
 
 [env.test2]
 aws_profile = test2
 bucket = my-bucket2
 table = my-table2
+config_table = my-config2
 
 [env.test3]
 aws_profile = test3
 bucket = my-bucket3
 table = my-table3
+config_table = my-config3
 
 [loglevels]
 root = INFO

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -8,11 +8,12 @@ from pydantic import BaseSettings
 
 
 class Environment(object):
-    def __init__(self, name, aws_profile, bucket, table):
+    def __init__(self, name, aws_profile, bucket, table, config_table):
         self.name = name
         self.aws_profile = aws_profile
         self.bucket = bucket
         self.table = table
+        self.config_table = config_table
 
 
 class MigrationMode(str, Enum):
@@ -178,12 +179,14 @@ def load_settings() -> Settings:
         aws_profile = config.get(env, "aws_profile", fallback=None)
         bucket = config.get(env, "bucket", fallback=None)
         table = config.get(env, "table", fallback=None)
+        config_table = config.get(env, "config_table", fallback=None)
         settings.environments.append(
             Environment(
                 name=env.replace("env.", ""),
                 aws_profile=aws_profile,
                 bucket=bucket,
                 table=table,
+                config_table=config_table,
             )
         )
 

--- a/tests/async_utils.py
+++ b/tests/async_utils.py
@@ -9,7 +9,7 @@ def assert_not_main_thread(message):
     It'll be included in the error message.
     """
 
-    thread = threading.currentThread()
+    thread = threading.current_thread()
     if thread != threading.main_thread():
         # OK, fine
         return

--- a/tests/aws/test_uri_alias.py
+++ b/tests/aws/test_uri_alias.py
@@ -1,0 +1,19 @@
+from logging import DEBUG
+
+from exodus_gw.aws.util import uri_alias
+
+
+def test_uri_alias(caplog):
+    caplog.set_level(DEBUG, logger="exodus-gw")
+    uri = "/content/origin/rpms/path/to/file.iso"
+    aliases = [
+        {"dest": "/origin", "src": "/content/origin"},
+        {"dest": "/origin/rpms", "src": "/origin/rpm"},
+    ]
+    expected = "/origin/rpms/path/to/file.iso"
+
+    assert uri_alias(uri, aliases) == "/origin/rpms/path/to/file.iso"
+    assert (
+        "Resolved alias:\n\tsrc: %s\n\tdest: %s" % (uri, expected)
+        in caplog.text
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,26 @@ from exodus_gw import auth, database, main, models, schemas, settings  # noqa
 
 from .async_utils import BlockDetector
 
+BASE_QUERY_RESPONSE = {
+    "ConsumedCapacity": {
+        "CapacityUnits": 1,
+        "GlobalSecondaryIndexes": {},
+        "LocalSecondaryIndexes": {},
+        "ReadCapacityUnits": 0,
+        "Table": {
+            "CapacityUnits": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0,
+        },
+        "TableName": "my-table",
+        "WriteCapacityUnits": 0,
+    },
+    "Count": 0,
+    "Items": [],
+    "LastEvaluatedKey": {},
+    "ScannedCount": 0,
+}
+
 
 @pytest.fixture(autouse=True)
 def mock_aws_client():
@@ -29,6 +49,7 @@ def mock_aws_client():
 def mock_boto3_client():
     with mock.patch("boto3.session.Session") as mock_session:
         client = mock.MagicMock()
+        client.query.return_value = BASE_QUERY_RESPONSE
         client.__enter__.return_value = client
         mock_session().client.return_value = client
         yield client

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -51,7 +51,13 @@ def test_publish_env_doesnt_exist(auth_header):
 
 def test_publish_links(mock_db_session):
     publish = routers.publish.publish(
-        env=Environment("test", "some-profile", "some-bucket", "some-table"),
+        env=Environment(
+            "test",
+            "some-profile",
+            "some-bucket",
+            "some-table",
+            "some-config-table",
+        ),
         db=mock_db_session,
     )
 

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -44,6 +44,7 @@ def test_load_settings_override(monkeypatch):
                 "aws_profile": "test",
                 "bucket": "my-bucket",
                 "table": "my-table",
+                "config_table": "my-config",
             },
         ),
         (
@@ -52,6 +53,7 @@ def test_load_settings_override(monkeypatch):
                 "aws_profile": "test2",
                 "bucket": "my-bucket2",
                 "table": "my-table2",
+                "config_table": "my-config2",
             },
         ),
         (
@@ -60,6 +62,7 @@ def test_load_settings_override(monkeypatch):
                 "aws_profile": "test3",
                 "bucket": "my-bucket3",
                 "table": "my-table3",
+                "config_table": "my-config3",
             },
         ),
         ("bad", None),
@@ -73,6 +76,7 @@ def test_get_environment(env, expected):
         assert env_obj.aws_profile == expected["aws_profile"]
         assert env_obj.bucket == expected["bucket"]
         assert env_obj.table == expected["table"]
+        assert env_obj.config_table == expected["config_table"]
 
     else:
         with pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
Because exodus-lambda maps uri aliases before looking them up on the
Exodus CDN, we must do the same when publishing to it. This commit
implements code which do just that while constructing DynamoDB write
requests.

Previously, exodus-gw would publish an item with a web_uri like
"/content/origin/rpms/some/file.iso". If exodus-lambda then receives a
request for "/content/origin/rpms/some/file.iso", it will resolve the
origin alias and futilely look for an item with a web_uri of
"/origin/rpms/some/file.iso".