### PR TITLE
tests: fix slightly flaky test_deploy_config

### DIFF
--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -80,7 +80,8 @@ def test_deploy_config(
     assert body["kwargs"]["task_id"] == str(t.id)
 
     # And actor call should have been delayed by this long.
-    assert (body["options"]["eta"] - body["message_timestamp"]) == 120000
+    delay = body["options"]["eta"] - body["message_timestamp"]
+    assert abs(delay - 120000) < 1000
 
 
 @mock.patch("exodus_gw.worker.deploy.CurrentMessage.get_current_message")


### PR DESCRIPTION
When checking the message delay we should not do a precise
millisecond-level comparison like this. The message handling isn't
instant and it is possible for the delay to be slightly higher than the
specified value.

Add a 1 second leeway onto the comparison to stabilize the test.