### PR TITLE
dev env: update scripts/instructions for config table

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -182,27 +182,18 @@ the development environment.
 
        - Other parameters can be omitted.
 
-   * - ``scripts/localstack-s3-init``
+   * - ``scripts/localstack-init``
 
-       ``scripts/localstack-s3-init some-bucket``
-
-     - Create a bucket in localstack.
+     - Create resources in localstack.
 
        The localstack environment is initially empty, which will make it impossible to
-       upload any objects. For upload to work with exodus-gw, you'll want to create one
-       or more buckets matching the info in ``exodus-gw.ini``. The script will make a bucket
-       matching the ``test`` environment if no name is specified.
+       upload any objects. For upload to work with exodus-gw, you'll want to create buckets
+       and DynamoDB tables matching the info in ``exodus-gw.ini``. This script will create
+       those resources.
 
-   * - ``scripts/localstack-dynamodb-init``
-
-       ``scripts/localstack-dynamodb-init some-table``
-
-     - Create a table in localstack.
-
-       The localstack environment is initially empty, which will make it impossible to
-       execute any publish tasks. For publish to work with exodus-gw, you'll want to create
-       one or more tables matching the info in ``exodus-gw.ini``. The script will make a table
-       matching the ``test`` environment if no name is specified.
+       The script uses defaults which are only appropriate for the ``test`` environment
+       defined in the repo's ``exodus-gw.ini``. Check the other ``localstack-*-init``
+       scripts if you need to create buckets/tables with other names.
 
    * - ``aws --endpoint-url=https://localhost:3377 s3 ls s3://my-bucket``
      - List files in localstack s3 bucket.

--- a/scripts/launch-devenv
+++ b/scripts/launch-devenv
@@ -45,8 +45,7 @@ setup_certs(){
 }
 
 init_aws_infra(){
-    scripts/localstack-s3-init
-    scripts/localstack-dynamodb-init
+    scripts/localstack-init
 }
 
 run(){

--- a/scripts/localstack-dynamodb-config-init
+++ b/scripts/localstack-dynamodb-config-init
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Create a dynamodb table for content in the dev env's localstack instance.
+# Create a dynamodb table for config in the dev env's localstack instance.
 #
 # You will need to run this when:
 # - initially creating the dev env, or
@@ -9,7 +9,7 @@
 #
 
 # should match table for the environment you want to use in exodus-gw.ini
-TABLE_NAME="${1:-my-table}"
+TABLE_NAME="${1:-my-config}"
 
 ENV_FILE="~/.config/exodus-gw-dev/.env"
 
@@ -24,8 +24,8 @@ exec aws \
    dynamodb \
    create-table \
    --table-name "${TABLE_NAME}" \
-  --attribute-definitions AttributeName=web_uri,AttributeType=S \
+  --attribute-definitions AttributeName=config_id,AttributeType=S \
                           AttributeName=from_date,AttributeType=S \
-  --key-schema AttributeName=web_uri,KeyType=HASH \
+  --key-schema AttributeName=config_id,KeyType=HASH \
                AttributeName=from_date,KeyType=RANGE \
   --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10

--- a/scripts/localstack-init
+++ b/scripts/localstack-init
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Populate localstack with basic resources needed for exodus-gw to run.
+#
+# This script accepts no arguments and is only usable for the default
+# config in exodus-gw.ini. If you want to deploy different buckets/tables,
+# invoke the localstack-*-init scripts separately.
+#
+# You will need to run this when:
+# - initially creating the dev env, or
+# - after cleaning it
+#
+thisdir=$(dirname $0)
+
+# Note: we continue on error here because the DDB steps will complain if
+# tables already exist, which is inconvenient
+set -x
+
+$thisdir/localstack-s3-init
+$thisdir/localstack-dynamodb-init
+$thisdir/localstack-dynamodb-config-init


### PR DESCRIPTION
When we introduced the second DynamoDB table in order to hold config,
the instructions and scripts here were never updated to cover creation
of it. Add it now.