### PR TITLE
dev env: tweak sscg execution conditions

### DIFF
--- a/scripts/systemd/exodus-gw-cert.service
+++ b/scripts/systemd/exodus-gw-cert.service
@@ -6,14 +6,20 @@ Description=exodus-gw development cert
 [Service]
 Type=oneshot
 ExecStartPre=mkdir -p %S/exodus-gw-dev
+
+# Only run if one of the outputs is missing or empty.
+ExecCondition=sh -c '! ( \
+  test -s %S/exodus-gw-dev/ca.crt && \
+  test -s %S/exodus-gw-dev/service.pem && \
+  test -s %S/exodus-gw-dev/service-key.pem \
+)'
+
 ExecStart=sscg \
   --cert-file=%S/exodus-gw-dev/service.pem \
   --cert-key-file=%S/exodus-gw-dev/service-key.pem \
   --ca-file=%S/exodus-gw-dev/ca.crt \
-  --subject-alt-name localhost
-
-# This exit code means the cert already exists, which is OK.
-SuccessExitStatus=17
+  --subject-alt-name localhost \
+  --force
 
 [Install]
 WantedBy=exodus-gw.target

--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -18,14 +18,6 @@ Environment=EXODUS_GW_SIDECAR_IMAGE=images.paas.redhat.com/it-platform/platform-
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 
-# Make self-signed cert
-ExecStartPre=mkdir -p %S/exodus-gw-dev
-ExecStartPre=-sscg \
-  --cert-file=%S/exodus-gw-dev/service.pem \
-  --cert-key-file=%S/exodus-gw-dev/service-key.pem \
-  --ca-file=%S/exodus-gw-dev/ca.crt \
-  --subject-alt-name localhost
-
 # Make properties file
 ExecStartPre=sh -c "cat >%S/exodus-gw-dev/platform-sidecar.yaml <<END\n\
 server.ssl.client-auth: want\n\


### PR DESCRIPTION
The dev env runs sscg in order to create certs.
It previously worked by always running sscg but tolerating an exit code
of 17, which was sscg's documented code for "output already exists".

Let's change it to instead only run sscg if one of the outputs doesn't
exist or is empty, because:

- the sscg "ERROR: File exists" message can be confusing and lead the
  developer to think that something has gone wrong.

- it is potentially useful to be able to recover from "cert exists but
  is empty", as this has been observed to happen at least once (though I
  don't know why).

Additionally, the duplication of sscg between exodus-gw-cert and
exodus-gw-sidecar has been removed so that this logic is only in one
place.