### PR TITLE
dev env: fix deprecated KillMode=none

### DIFF
--- a/scripts/systemd/exodus-gw-db.service
+++ b/scripts/systemd/exodus-gw-db.service
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n-pid --cidfile %t/%n-cid --c
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n-cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 PIDFile=%t/%n-pid
-KillMode=none
+TimeoutStopSec=60
 Type=forking
 
 [Install]

--- a/scripts/systemd/exodus-gw-localstack.service
+++ b/scripts/systemd/exodus-gw-localstack.service
@@ -49,7 +49,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n-pid --cidfile %t/%n-cid --c
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n-cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 PIDFile=%t/%n-pid
-KillMode=none
+TimeoutStopSec=60
 Type=forking
 
 [Install]

--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -62,7 +62,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n-pid --cidfile %t/%n-cid --c
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n-cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 PIDFile=%t/%n-pid
-KillMode=none
+TimeoutStopSec=60
 Type=forking
 
 [Install]


### PR DESCRIPTION
These units were originally created by "podman generate systemd"
which inserted a KillMode=none directive. That value of KillMode
was deprecated by systemd and will be removed in the future.

This commit updates the units to be aligned with podman's fix for
the issue in https://github.com/containers/podman/issues/8615,
which was to drop KillMode and add TimeoutStopSec.