### PR TITLE
dev env: create & enforce 'test' aws profile during localstack setup

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -166,22 +166,6 @@ the development environment.
    * - ``curl https://localhost:3377``
      - Sanity check for localstack
 
-   * - ``aws configure --profile test``
-     - Create a ``test`` profile for AWS CLI.
-
-       In order for exodus-gw to work, an AWS profile must exist in ``~/.aws/credentials``
-       matching the ``aws_profile`` in ``exodus-gw.ini``.  This command will help to create
-       a profile if you don't already have one.
-
-       It'll prompt for a few parameters:
-
-       - For region, use ``us-east-1``.
-
-       - For access keys, use any dummy value (e.g. ``"x"``) - these won't be used,
-         but must be present.
-
-       - Other parameters can be omitted.
-
    * - ``scripts/localstack-init``
 
      - Create resources in localstack.

--- a/scripts/localstack-init
+++ b/scripts/localstack-init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Populate localstack with basic resources needed for exodus-gw to run.
 #
@@ -12,9 +12,29 @@
 #
 thisdir=$(dirname $0)
 
+ensure_aws_profile()(
+  # Ensure the user has an AWS profile named 'test' (name matching
+  # the profile expected in exodus-gw.ini).
+  #
+  # If the profile already exists, we do nothing since the user might
+  # have configured it a certain way and we shouldn't mess with it.
+  # However if it doesn't exist, we define a minimal one.
+  if ! aws configure list-profiles | egrep --silent "^test$"; then
+    aws configure set profile.test.region us-east-1
+    aws configure set profile.test.aws_access_key_id fake-key-id
+    aws configure set profile.test.aws_secret_access_key fake-key
+  fi
+)
+
+set -e
+ensure_aws_profile
+export AWS_PROFILE=test
+
+set -x
+
 # Note: we continue on error here because the DDB steps will complain if
 # tables already exist, which is inconvenient
-set -x
+set +e
 
 $thisdir/localstack-s3-init
 $thisdir/localstack-dynamodb-init


### PR DESCRIPTION
It seems that the aws commands used in the localstack-* init scripts
were using the environment's default profile (or the profile set by the
user in AWS_PROFILE).

In a clean environment, that's a problem since no profile will exist;
and even though our docs suggested creating a "test" profile, these
scripts didn't attempt to use that profile, so it wouldn't help unless
the caller explicitly set AWS_PROFILE=test.

Let's make it a bit more robust:

- localstack-init will check for a 'test' aws profile and create it if
  missing.
- localstack-init always attempts to use the 'test' aws profile.