### PR TITLE
docs: various API doc improvements for recent features

### DIFF
--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -7,6 +7,8 @@ Available APIs are grouped into the following categories:
   S3 compatible.
 - [publish](#tag/publish): atomically publish a set of blobs on the CDN under specified paths,
   making them accessible to end-users.
+- [deploy](#tag/deploy): deploy configuration influencing the behavior of the CDN.
+- [cdn](#tag/cdn): utilities for accessing the CDN.
 
 ## Overview of API usage
 
@@ -83,6 +85,8 @@ app = FastAPI(
         service.openapi_tag,
         upload.openapi_tag,
         publish.openapi_tag,
+        deploy.openapi_tag,
+        cdn.openapi_tag,
     ],
 )
 app.include_router(service.router)


### PR DESCRIPTION
- in the main API overview, add links for the deploy & cdn APIs.

- on the FastAPI app object, make sure we add the openapi_tag objects
  from the deploy/cdn modules. Without this, the module-level doc
  strings never end up in the rendered docs.

- revise those module-level doc strings so they don't repeat info in the
  doc string on each endpoint.

- redirect: avoid duplicate docs between the GET and HEAD methods

- redirect: flesh out some missing details, including URL parameter,
  status code and location header.

- redirect: revise the description to focus more on the purpose of the
  endpoint, rather than how it's implemented.

- deploy: tweak the response summary (replacing default "Successful
  Response" with "Deployment enqueued") to be consistent with the
  established style.

- deploy: document the request body (beyond just an example). Since
  openapi itself uses JSON Schema, the existing schema can be used for
  this after adding some description strings.