### PR TITLE
dev env: enable secretsmanager in localstack

### DIFF
--- a/scripts/systemd/exodus-gw-localstack.service
+++ b/scripts/systemd/exodus-gw-localstack.service
@@ -41,7 +41,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n-pid --cidfile %t/%n-cid --c
   --log-driver journald\
   -v %S/exodus-gw-dev/localstack:/tmp/localstack:z\
   -e DATA_DIR=/tmp/localstack/data\
-  -e SERVICES=s3,dynamodb\
+  -e SERVICES=s3,dynamodb,secretsmanager\
   -e DEBUG=1\
   -e EDGE_PORT=${EXODUS_GW_LOCALSTACK_PORT}\
   ${EXODUS_GW_LOCALSTACK_IMAGE}


### PR DESCRIPTION
While exodus-gw itself doesn't use secretsmanager, it is used from other
exodus components. Let's enable it so those components can be tested
against this localstack.