### PR TITLE
Reuse S3 connections [RHELDST-4926]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -169,6 +169,9 @@ class Settings(BaseSettings):
     cdn_signature_timeout: int = 60 * 30
     """Time (in seconds) signed URLs remain valid."""
 
+    s3_pool_size: int = 3
+    """Number of S3 clients to cache"""
+
     class Config:
         env_prefix = "exodus_gw_"
 

--- a/tests/aws/test_content_md5.py
+++ b/tests/aws/test_content_md5.py
@@ -3,6 +3,16 @@ import mock
 from exodus_gw.aws.util import content_md5
 
 
+def test_content_md5():
+    request = mock.MagicMock()
+    request.headers = {
+        "Content-Length": 1258,
+        "Content-MD5": "28d4b03bdd69e77917638c3ef6b8720b",
+    }
+
+    assert content_md5(request) == "28d4b03bdd69e77917638c3ef6b8720b"
+
+
 def test_empty_content_md5():
     """When the Content-Length header is 0, no Content-MD5 is present
     and content_md5 returns equivalent value for no content.

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -1,38 +1,30 @@
 import pytest
 from botocore.exceptions import ClientError
+from fastapi.testclient import TestClient
 
-from exodus_gw.routers.upload import head
-from exodus_gw.settings import get_environment
+from exodus_gw.main import app
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
 @pytest.mark.asyncio
-async def test_head(mock_aws_client):
+async def test_head(mock_aws_client, auth_header):
     """Head request is delegated correctly to S3."""
 
     mock_aws_client.head_object.return_value = {"ETag": "a1b2c3"}
 
-    response = await head(
-        env=get_environment("test"),
-        key=TEST_KEY,
-    )
+    with TestClient(app) as client:
+        r = client.head(
+            "/upload/test/%s" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
+        )
 
-    # It should delegate request to real S3
-    mock_aws_client.head_object.assert_called_once_with(
-        Bucket="my-bucket",
-        Key=TEST_KEY,
-    )
-
-    # It should succeed
-    assert response.status_code == 200
-
-    # Response should contain the ETag
-    assert response.headers["ETag"] == "a1b2c3"
+    assert r.ok
+    assert r.headers == {"ETag": "a1b2c3"}
 
 
 @pytest.mark.asyncio
-async def test_head_nonexistent_key(mock_aws_client):
+async def test_head_nonexistent_key(mock_aws_client, auth_header):
     """Head handles 404 responses correctly."""
 
     mock_aws_client.head_object.side_effect = ClientError(
@@ -40,23 +32,17 @@ async def test_head_nonexistent_key(mock_aws_client):
         "HeadObject",
     )
 
-    response = await head(
-        env=get_environment("test"),
-        key=TEST_KEY,
-    )
+    with TestClient(app) as client:
+        r = client.head(
+            "/upload/test/%s" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
+        )
 
-    # It should delegate request to real S3 without raising exception
-    mock_aws_client.head_object.assert_called_once_with(
-        Bucket="my-bucket",
-        Key=TEST_KEY,
-    )
-
-    # It should fail
-    assert response.status_code == 404
+    assert r.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_head_logs_error(mock_aws_client, caplog):
+async def test_head_logs_error(mock_aws_client, auth_header, caplog):
     """Head logs unexpected errors correctly."""
 
     mock_aws_client.head_object.side_effect = ClientError(
@@ -64,19 +50,11 @@ async def test_head_logs_error(mock_aws_client, caplog):
         "HeadObject",
     )
 
-    response = await head(
-        env=get_environment("test"),
-        key=TEST_KEY,
-    )
+    with TestClient(app) as client:
+        r = client.head(
+            "/upload/test/%s" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
+        )
 
-    # It should delegate request to real S3 without raising exception
-    mock_aws_client.head_object.assert_called_once_with(
-        Bucket="my-bucket",
-        Key=TEST_KEY,
-    )
-
-    # It should pass back the status code
-    assert response.status_code == 501
-
-    # It should log a message
+    assert r.status_code == 501
     assert "HEAD to S3 failed" in caplog.text

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -2,17 +2,19 @@ import textwrap
 
 import mock
 import pytest
-from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 from exodus_gw.aws.util import xml_response
-from exodus_gw.routers.upload import abort_multipart_upload, multipart_upload
-from exodus_gw.settings import get_environment
+from exodus_gw.deps import get_environment, get_s3_client, get_settings
+from exodus_gw.main import app
+from exodus_gw.routers.upload import multipart_upload
+from exodus_gw.settings import load_settings
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
 @pytest.mark.asyncio
-async def test_create_mpu(mock_aws_client):
+async def test_create_mpu(mock_aws_client, auth_header):
     """Creating a multipart upload is delegated correctly to S3."""
 
     mock_aws_client.create_multipart_upload.return_value = {
@@ -21,24 +23,17 @@ async def test_create_mpu(mock_aws_client):
         "UploadId": "my-great-upload",
     }
 
-    response = await multipart_upload(
-        None,
-        env=get_environment("test"),
-        key=TEST_KEY,
-        uploads="",
-    )
-
-    # It should delegate request to real S3
-    mock_aws_client.create_multipart_upload.assert_called_once_with(
-        Bucket="my-bucket",
-        Key=TEST_KEY,
-    )
+    with TestClient(app) as client:
+        r = client.post(
+            "/upload/test/%s?uploads" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
+        )
 
     # It should succeed
-    assert response.status_code == 200
+    assert r.status_code == 200
 
     # It should be XML
-    assert response.headers["content-type"] == "application/xml"
+    assert r.headers["content-type"] == "application/xml"
 
     # It should include the appropriate data
     expected = xml_response(
@@ -47,7 +42,7 @@ async def test_create_mpu(mock_aws_client):
         Key=TEST_KEY,
         UploadId="my-great-upload",
     ).body
-    assert response.body == expected
+    assert r.content == expected
 
 
 @pytest.mark.asyncio
@@ -60,6 +55,9 @@ async def test_complete_mpu(mock_aws_client):
         "Key": TEST_KEY,
         "ETag": "my-better-etag",
     }
+
+    env = get_environment("test")
+    settings = load_settings()
 
     # Need some valid request body to complete an MPU
     request = mock.AsyncMock()
@@ -78,10 +76,17 @@ async def test_complete_mpu(mock_aws_client):
             </CompleteMultipartUpload>
         """
     ).strip()
+    request.app.state.settings = settings
+    request.app.state.s3_queues = {}
+
+    s3_client = await get_s3_client(
+        request=request, env=env, settings=settings
+    ).__anext__()
 
     response = await multipart_upload(
         request=request,
-        env=get_environment("test"),
+        env=env,
+        s3=s3_client,
         key=TEST_KEY,
         uploadId="my-better-upload",
         uploads=None,
@@ -118,38 +123,36 @@ async def test_complete_mpu(mock_aws_client):
 
 
 @pytest.mark.asyncio
-async def test_bad_mpu_call():
+async def test_bad_mpu_call(auth_header):
     """Mixing uploadId and uploads arguments gives a validation error."""
 
-    with pytest.raises(HTTPException) as exc_info:
-        await multipart_upload(
-            request=None,
-            env=get_environment("test"),
-            key=TEST_KEY,
-            uploadId="oops",
-            uploads="not valid to mix these args",
+    with TestClient(app) as client:
+        r = client.post(
+            "/upload/test/%s?uploads&uploadId=my-upload" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
         )
 
-    assert exc_info.value.status_code == 400
+    assert r.status_code == 400
+    assert r.content == (
+        b"<?xml version='1.0' encoding='UTF-8'?>\n"
+        b"<Error>"
+        b"<Code>400</Code>"
+        b"<Message>Invalid uploadId='my-upload', uploads=''</Message>"
+        b"<Endpoint>/upload/test/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c</Endpoint>"
+        b"</Error>"
+    )
 
 
 @pytest.mark.asyncio
-async def test_abort_mpu(mock_aws_client):
+async def test_abort_mpu(mock_aws_client, auth_header):
     """Aborting a multipart upload is correctly delegated to S3."""
 
-    response = await abort_multipart_upload(
-        env=get_environment("test"),
-        key=TEST_KEY,
-        uploadId="my-lame-upload",
-    )
-
-    # It should delegate the request to real S3
-    mock_aws_client.abort_multipart_upload.assert_called_once_with(
-        Bucket="my-bucket",
-        Key=TEST_KEY,
-        UploadId="my-lame-upload",
-    )
+    with TestClient(app) as client:
+        r = client.delete(
+            "/upload/test/%s?uploadId=my-lame-upload" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
+        )
 
     # It should be a successful, empty response
-    assert response.status_code == 200
-    assert response.body == b""
+    assert r.status_code == 200
+    assert r.content == b""


### PR DESCRIPTION
This commit introduces caching for AWS S3 clients to reduce overhead
of the upload API.