### PR TITLE
Improve Publish model's resolve_links [RHELDST-11634]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.8
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
     - id: isort
       language_version: python3.8

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -577,14 +577,34 @@ def test_commit_publish_prev_completed(mock_commit, fake_publish, db):
 def test_commit_publish_linked_items(mock_commit, fake_publish, db):
     """Ensure commit_publish correctly resolves links."""
 
-    # Add an item with link to an existing item.
-    ln_item = Item(
+    # Whole items
+    item1 = Item(
+        web_uri="/some/path",
+        object_key="1" * 64,
+        publish_id=fake_publish.id,
+    )
+    item2 = Item(
+        web_uri="/another/path",
+        object_key="2" * 64,
+        publish_id=fake_publish.id,
+    )
+    item3 = Item(
+        web_uri="/some/different/path",
+        object_key="3" * 64,
+        publish_id=fake_publish.id,
+    )
+    # Linked items
+    ln_item1 = Item(
         web_uri="/alternate/route/to/some/path",
-        object_key="",
         link_to="/some/path",
         publish_id=fake_publish.id,
     )
-    fake_publish.items.append(ln_item)
+    ln_item2 = Item(
+        web_uri="/alternate/route/to/another/path",
+        link_to="/another/path",
+        publish_id=fake_publish.id,
+    )
+    fake_publish.items.extend([item1, item2, item3, ln_item1, ln_item2])
 
     db.add(fake_publish)
     db.commit()
@@ -596,10 +616,10 @@ def test_commit_publish_linked_items(mock_commit, fake_publish, db):
         settings=Settings(),
     )
 
-    # Should've filled item's object_key with known value.
-    assert ln_item.object_key == (
-        "0bacfc5268f9994065dd858ece3359fd7a99d82af5be84202b8e84c2a5b07ffa"
-    )
+    # Should've filled ln_item1's object_key with that of item1.
+    assert ln_item1.object_key == "1" * 64
+    # Should've filled ln_item2's object_key with that of item2.
+    assert ln_item2.object_key == "2" * 64
     # Should've created and sent task.
     assert isinstance(publish_task, Task)
 


### PR DESCRIPTION
Previously this method loaded every item on the publish, storing them in
memory for its duration. The number of these items can realistically
reach into many hundreds of thousands, approaching a million.

This commit refactors the method to use a querying approach to store
only the items that it needs to operate on -- those with non-empty
link_to fields -- and load only the URI and object key of the
corresponding items. These changes should significantly reduce the
impact this method has on system memory.