### PR TITLE
tests: fix pytest-asyncio deprecation warning

### DIFF
--- a/tests/auth/test_call_context.py
+++ b/tests/auth/test_call_context.py
@@ -9,7 +9,6 @@ from exodus_gw.auth import call_context
 from exodus_gw.settings import Settings
 
 
-@pytest.mark.asyncio
 async def test_no_context():
     """Unauthenticated requests return a default context."""
 
@@ -29,7 +28,6 @@ async def test_no_context():
     assert not ctx.user.authenticated
 
 
-@pytest.mark.asyncio
 async def test_decode_context():
     """A context can be decoded from a valid header."""
 
@@ -63,7 +61,6 @@ async def test_decode_context():
     assert ctx.user.internalUsername == "greatUser"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "header_value",
     [

--- a/tests/auth/test_roles.py
+++ b/tests/auth/test_roles.py
@@ -10,14 +10,12 @@ from exodus_gw.auth import (
 )
 
 
-@pytest.mark.asyncio
 async def test_caller_roles_empty():
     """caller_roles returns an empty set for a default (empty) context."""
 
     assert (await caller_roles(CallContext())) == set()
 
 
-@pytest.mark.asyncio
 async def test_caller_roles_nonempty():
     """caller_roles returns all roles from the context when present."""
 
@@ -28,7 +26,6 @@ async def test_caller_roles_nonempty():
     assert (await caller_roles(ctx)) == set(["role1", "role2", "role3"])
 
 
-@pytest.mark.asyncio
 async def test_needs_role_success():
     """needs_role succeeds when needed role is present."""
 
@@ -38,7 +35,6 @@ async def test_needs_role_success():
     await fn(roles=set(["better-role"]))
 
 
-@pytest.mark.asyncio
 async def test_needs_role_fail():
     """needs_role raises meaningful error when needed role is absent."""
 

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -4,7 +4,6 @@ import pytest
 from exodus_gw.aws.client import S3ClientWrapper as s3_client
 
 
-@pytest.mark.asyncio
 async def test_client_retries_disabled():
     """Verify that created S3 clients have retries disabled in config."""
 
@@ -16,7 +15,6 @@ async def test_client_retries_disabled():
         assert config.retries == {"max_attempts": 1}
 
 
-@pytest.mark.asyncio
 async def test_client_redirects_disabled():
     """Verify that created S3 clients have disabled the implicit region redirect feature
     in boto library."""

--- a/tests/aws/test_request_reader.py
+++ b/tests/aws/test_request_reader.py
@@ -12,7 +12,6 @@ class FakeRequest:
             yield chunk
 
 
-@pytest.mark.asyncio
 async def test_iterate_stream():
     request = FakeRequest([b"first ", b"second ", b"third"])
 

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -9,7 +9,6 @@ from exodus_gw.models import DramatiqConsumer
 from exodus_gw.routers import service
 
 
-@pytest.mark.asyncio
 async def test_healthcheck():
     assert (await service.healthcheck()) == {"detail": "exodus-gw is running"}
 
@@ -50,7 +49,6 @@ def test_healthcheck_worker_unhealthy(db):
         assert r.json() == {"detail": "background workers unavailable"}
 
 
-@pytest.mark.asyncio
 async def test_whoami():
     # All work is done by fastapi deserialization, so this doesn't actually
     # do anything except return the passed object.

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -7,7 +7,6 @@ from exodus_gw.main import app
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
-@pytest.mark.asyncio
 async def test_head(mock_aws_client, auth_header):
     """Head request is delegated correctly to S3."""
 
@@ -23,7 +22,6 @@ async def test_head(mock_aws_client, auth_header):
     assert r.headers == {"ETag": "a1b2c3"}
 
 
-@pytest.mark.asyncio
 async def test_head_nonexistent_key(mock_aws_client, auth_header):
     """Head handles 404 responses correctly."""
 
@@ -41,7 +39,6 @@ async def test_head_nonexistent_key(mock_aws_client, auth_header):
     assert r.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_head_logs_error(mock_aws_client, auth_header, caplog):
     """Head logs unexpected errors correctly."""
 

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -13,7 +13,6 @@ from exodus_gw.settings import load_settings
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
-@pytest.mark.asyncio
 async def test_create_mpu(mock_aws_client, auth_header):
     """Creating a multipart upload is delegated correctly to S3."""
 
@@ -45,7 +44,6 @@ async def test_create_mpu(mock_aws_client, auth_header):
     assert r.content == expected
 
 
-@pytest.mark.asyncio
 async def test_complete_mpu(mock_aws_client):
     """Completing a multipart upload is delegated correctly to S3."""
 
@@ -122,7 +120,6 @@ async def test_complete_mpu(mock_aws_client):
     assert response.body == expected
 
 
-@pytest.mark.asyncio
 async def test_bad_mpu_call(auth_header):
     """Mixing uploadId and uploads arguments gives a validation error."""
 
@@ -143,7 +140,6 @@ async def test_bad_mpu_call(auth_header):
     )
 
 
-@pytest.mark.asyncio
 async def test_abort_mpu(mock_aws_client, auth_header):
     """Aborting a multipart upload is correctly delegated to S3."""
 

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -6,7 +6,6 @@ from exodus_gw.main import app
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
-@pytest.mark.asyncio
 async def test_full_upload(mock_aws_client, mock_request_reader, auth_header):
     """Uploading a complete object is delegated correctly to S3."""
 
@@ -29,7 +28,6 @@ async def test_full_upload(mock_aws_client, mock_request_reader, auth_header):
     assert r.content == b""
 
 
-@pytest.mark.asyncio
 async def test_part_upload(mock_aws_client, mock_request_reader, auth_header):
     """Uploading part of an object is delegated correctly to S3."""
 

--- a/tests/test_exception_handler.py
+++ b/tests/test_exception_handler.py
@@ -7,7 +7,6 @@ from exodus_gw.main import custom_http_exception_handler
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "endpoint, media_type",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ commands=
 [pytest]
 testpaths = tests
 addopts = -v
+asyncio_mode = auto
 
 [coverage:run]
 relative_files = true


### PR DESCRIPTION
pytest-asyncio for some time generates the following deprecation
warning:

    The 'asyncio_mode' default value will change to 'strict' in future,
    please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto'
    in pytest configuration file.

Do what it says. 'auto' is recommended (as long as you aren't mixing
multiple asyncio test frameworks together), so we'll use that. This
allows the asyncio marker to be dropped from all the tests.