### PR TITLE
Fix shutdown of S3 clients after connection pool introduced

### DIFF
--- a/exodus_gw/deps.py
+++ b/exodus_gw/deps.py
@@ -1,5 +1,6 @@
 """Functions intended for use with fastapi.Depends."""
 
+import sys
 from asyncio import LifoQueue
 
 from fastapi import Depends, Path, Request
@@ -66,12 +67,12 @@ async def get_s3_client(
 
     try:
         yield client
-    except Exception as exc_info:
+    except Exception:
         # When an exception is raised, assume the client broke.
         # Close the client and replace it before raising.
-        client.__aexit__()
+        await client.__aexit__(*sys.exc_info())
         client = await S3ClientWrapper(profile=profile).__aenter__()
-        raise exc_info
+        raise
     finally:
         await queue.put(client)
 

--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -152,11 +152,11 @@ def s3_queues_init() -> None:
     app.state.s3_queues = {}
 
 
-def s3_queues_shutdown() -> None:
+async def s3_queues_shutdown() -> None:
     for q in app.state.s3_queues.values():
         while not q.empty():
             client = q.get_nowait()
-            client.__aexit__()
+            await client.__aexit__(None, None, None)
 
 
 @app.on_event("startup")
@@ -168,9 +168,9 @@ def on_startup() -> None:
 
 
 @app.on_event("shutdown")
-def on_shutdown() -> None:
+async def on_shutdown() -> None:
     db_shutdown()
-    s3_queues_shutdown()
+    await s3_queues_shutdown()
 
 
 def new_db_session(engine):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,16 @@ from exodus_gw.dramatiq import Broker
 from .async_utils import BlockDetector
 
 
+async def fake_aexit_instancemethod(self, exc_type, exc_val, exc_tb):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def mock_aws_client():
     with mock.patch("aioboto3.Session") as mock_session:
         aws_client = mock.AsyncMock()
         aws_client.__aenter__.return_value = aws_client
+        aws_client.__aexit__ = fake_aexit_instancemethod
         # This sub-object uses regular methods, not async
         aws_client.meta = mock.MagicMock()
         mock_session().client.return_value = aws_client

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,14 @@ commands=
 
 [pytest]
 testpaths = tests
-addopts = -v
+addopts =
+    -v
+    # Turn 'coroutine ... was never awaited' warnings into errors...
+    -Werror:coroutine:RuntimeWarning
+    # ..and we also have to turn these into errors, because those coroutine
+    # warnings happen outside of test functions and pytest will otherwise
+    # not allow them to be raised
+    -Werror::pytest.PytestUnraisableExceptionWarning
 asyncio_mode = auto
 
 [coverage:run]


### PR DESCRIPTION
There were two problems here with client shutdown:

1. \_\_aexit\_\_ is an async method and the result needs to be awaited. Fix
   that, and adjust test suite arguments to turn some warnings into
   errors so that the same mistake can't happen again.

2. \_\_aexit\_\_ needs some arguments. Calling it with no arguments will
   crash. Fix that, and fix the inaccurate mock which allowed tests to
   miss the error.