### PR TITLE
Correct resolve_links query [RHELDST-11634]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -27,7 +27,13 @@ class Publish(Base):
 
     def resolve_links(self):
         db = inspect(self).session
-        ln_items = db.query(Item).filter(Item.link_to != None).all()
+        # Store only publish items with link targets.
+        ln_items = (
+            db.query(Item)
+            .filter(Item.publish_id == self.id, Item.link_to != None)
+            .all()
+        )
+        # Collect link targets of linked items for finding matches.
         ln_item_paths = [item.link_to for item in ln_items]
 
         # Store only necessary fields from matching items to conserve memory.


### PR DESCRIPTION
Previously, when querying linked items, no filter was placed on the
publish ID. This commit corrects the query to select only linked items
on the publish table of concern.