### PR TITLE
Filter null and empty strings in Publish's resolve_links [RHELDST-11634]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -2,7 +2,15 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import HTTPException
-from sqlalchemy import Column, DateTime, ForeignKey, String, event, inspect
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    String,
+    event,
+    func,
+    inspect,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Bundle, relationship
 
@@ -30,7 +38,8 @@ class Publish(Base):
         # Store only publish items with link targets.
         ln_items = (
             db.query(Item)
-            .filter(Item.publish_id == self.id, Item.link_to != None)
+            .filter(Item.publish_id == self.id)
+            .filter(func.coalesce(Item.link_to, "") != "")
             .all()
         )
         # Collect link targets of linked items for finding matches.

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -582,11 +582,13 @@ def test_commit_publish_linked_items(mock_commit, fake_publish, db):
         web_uri="/some/path",
         object_key="1" * 64,
         publish_id=fake_publish.id,
+        link_to=None,  # It should be able to handle None/NULL link_to values...
     )
     item2 = Item(
         web_uri="/another/path",
         object_key="2" * 64,
         publish_id=fake_publish.id,
+        link_to="",  # ...and empty string link_to values...
     )
     item3 = Item(
         web_uri="/some/different/path",


### PR DESCRIPTION
When querying for publish items with link_to set, all others were
expected to have link_to=None. However, clients are able, and often do,
set link_to to an empty string rather than leaving it unset or None.

This commit improves the query to account for this by reading NULL/None
values as empty strings and filtering those instead.