### PR TITLE
Fix exodus-gw worker DB errors on startup [RHELDST-11593]

### DIFF
--- a/exodus_gw/dramatiq/broker.py
+++ b/exodus_gw/dramatiq/broker.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from exodus_gw.database import db_engine
 from exodus_gw.dramatiq.consumer import Consumer
 from exodus_gw.dramatiq.middleware import (
+    DatabaseReadyMiddleware,
     LocalNotifyMiddleware,
     PostgresNotifyMiddleware,
     SchedulerMiddleware,
@@ -43,6 +44,9 @@ class Broker(dramatiq.Broker):  # pylint: disable=abstract-method
         )
 
         self.add_middleware(LocalNotifyMiddleware())
+
+        # Enable Database readycheck when booting up a worker.
+        self.add_middleware(DatabaseReadyMiddleware(self.__db_engine))
 
         # This is postgres-specific, so...
         if "postgresql" in str(self.__db_engine.url):

--- a/exodus_gw/dramatiq/middleware/__init__.py
+++ b/exodus_gw/dramatiq/middleware/__init__.py
@@ -1,3 +1,4 @@
+from .db_ready import DatabaseReadyMiddleware
 from .local_notify import LocalNotifyMiddleware
 from .pg_notify import PostgresNotifyMiddleware
 from .scheduler import SchedulerMiddleware
@@ -6,4 +7,5 @@ __all__ = [
     "LocalNotifyMiddleware",
     "PostgresNotifyMiddleware",
     "SchedulerMiddleware",
+    "DatabaseReadyMiddleware",
 ]

--- a/exodus_gw/dramatiq/middleware/db_ready.py
+++ b/exodus_gw/dramatiq/middleware/db_ready.py
@@ -1,0 +1,22 @@
+import backoff
+from dramatiq import Middleware
+from sqlalchemy import inspect
+
+
+@backoff.on_predicate(
+    wait_gen=backoff.expo,
+    max_tries=24,
+    max_time=120,
+)
+def db_table_check(engine, table):
+    return inspect(engine).has_table(table)
+
+
+class DatabaseReadyMiddleware(Middleware):
+    """Middleware for checking if DB is ready."""
+
+    def __init__(self, db_engine):
+        self.__db_engine = db_engine
+
+    def after_process_boot(self, broker):
+        db_table_check(self.__db_engine, "dramatiq_consumers")


### PR DESCRIPTION
Currently, we consider the two exodus components as "web" and "workder".

* the web component is responsible for running DB migrations during the
  initialization of the web app
* the worker component does not run DB migrations, it simply assumes the
  DB is up-to-date.

When booting up worker, the web component initialization can be
unfinished. This patch adds DB check when booting up a worker.