### PR TITLE
Fix logging config not respected by worker [RHELDST-12333]

### DIFF
--- a/exodus_gw/dramatiq/broker.py
+++ b/exodus_gw/dramatiq/broker.py
@@ -17,8 +17,9 @@ from exodus_gw.dramatiq.middleware import (
     PostgresNotifyMiddleware,
     SchedulerMiddleware,
 )
+from exodus_gw.logging import loggers_init
 from exodus_gw.models import DramatiqMessage
-from exodus_gw.settings import Settings
+from exodus_gw.settings import load_settings
 
 LOG = logging.getLogger("exodus-gw")
 
@@ -29,11 +30,13 @@ class Broker(dramatiq.Broker):  # pylint: disable=abstract-method
     def __init__(self, middleware=None, settings=None):
         super().__init__(middleware=middleware)
 
-        self.__settings = settings or Settings()
+        self.__settings = settings or load_settings()
         self.__db_engine = db_engine(self.__settings)
         self.__shared_session = ContextVar("shared_session")
         self.__broker_id = uuid.uuid4()
         self.__queue_events = defaultdict(Event)
+
+        loggers_init(self.__settings)
 
         # We have some actors using this, so it's always enabled.
         self.add_middleware(CurrentMessage())

--- a/exodus_gw/logging.py
+++ b/exodus_gw/logging.py
@@ -1,0 +1,16 @@
+import logging
+import logging.config
+
+
+def loggers_init(settings):
+    logging.config.dictConfig(settings.log_config)
+
+    root = logging.getLogger()
+    if not root.hasHandlers():
+        fmtr = logging.Formatter(
+            fmt="[%(asctime)s] [%(process)s] [%(levelname)s] %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S %z",
+        )
+        hdlr = logging.StreamHandler()
+        hdlr.setFormatter(fmtr)
+        root.addHandler(hdlr)

--- a/tests/dramatiq/test_broker_inits_loggers.py
+++ b/tests/dramatiq/test_broker_inits_loggers.py
@@ -1,0 +1,22 @@
+import logging
+
+from exodus_gw.dramatiq.broker import Broker
+
+
+def test_broker_inits_loggers(tmpdir, monkeypatch):
+    """Constructing a broker should set log levels according to config file."""
+
+    # Set up a config file which assigns non-default log levels.
+    ini = tmpdir.join("exodus-gw.ini")
+    ini.write("[loglevels]\nmy-great-logger = DEBUG\n")
+    monkeypatch.setenv("EXODUS_GW_INI_PATH", str(ini))
+
+    # Initially, my logger shouldn't have any level set.
+    assert logging.getLogger("my-great-logger").level == logging.NOTSET
+
+    # But if I construct a broker...
+    Broker()
+
+    # That should force loading settings and configuring loggers,
+    # so the level should now be what I requested
+    assert logging.getLogger("my-great-logger").level == logging.DEBUG


### PR DESCRIPTION
The Settings class takes settings from two sources: environment
variables and exodus-gw.ini. All logging config lives in the INI
file.

Problem: the proper loading of settings and initialization of loggers
was hooked into the WSGI app startup and not used for the worker
component, which would simply construct a 'Settings()'. This meant any
non-env-var config would be silently missed by the worker, including
configuration of the loggers.

Hence, adjusting the log level would have no effect for the worker process.

Fix it by ensuring that the worker loads settings properly and
initializes loggers on startup. The logger initialization shares code
with the web component. A minor change to .ini file loading was also
added to improve testability, as it was not previously possible to make
a test point at a specific config file.