### PR TITLE
dev env: tweak suggested awscli commands

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -179,12 +179,12 @@ the development environment.
        defined in the repo's ``exodus-gw.ini``. Check the other ``localstack-*-init``
        scripts if you need to create buckets/tables with other names.
 
-   * - ``aws --endpoint-url=https://localhost:3377 s3 ls s3://my-bucket``
+   * - ``env AWS_PROFILE=test aws --endpoint-url=https://localhost:3377 s3 ls s3://my-bucket``
      - List files in localstack s3 bucket.
 
        Can be used to check the outcome of an upload.
 
-   * - ``aws --endpoint-url=https://localhost:3377 dynamodb scan --table-name my-table``
+   * - ``env AWS_PROFILE=test aws --endpoint-url=https://localhost:3377 dynamodb scan --table-name my-table``
      - Dump all content of a dynamodb table in localstack.
 
        Can be used to check the outcome of a publish.

--- a/scripts/systemd/install
+++ b/scripts/systemd/install
@@ -117,7 +117,7 @@ Suggested commands:
   curl http://localhost:8000/healthcheck-worker
 
   # Create a test bucket in localstack
-  aws --endpoint-url=http://localhost:3377 s3api create-bucket --bucket test
+  env AWS_PROFILE=test aws --endpoint-url=http://localhost:3377 s3api create-bucket --bucket test
 
   # Install CA certificate to system bundle
   sudo cp $CONFIG_DIR/ca.crt /etc/pki/ca-trust/source/anchors/exodus-gw-dev.crt


### PR DESCRIPTION
Because no profile was specified, the commands as documented here might
not actually work - it would depend on the state of the caller's AWS
config files.

We know that a profile named 'test' should exist because
scripts/localstack-init creates one if needed, so let's adjust the
commands to refer to it. It should make the commands a bit more reliable
across environments.