### PR TITLE
dev env: integrate support for fakefront

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -42,10 +42,11 @@ a complete instance of the service in Kubernetes/OpenShift.
 This development environment includes:
 
 - exodus-gw uvicorn server (http)
-- sidecar proxy container (https)
+- sidecar proxy container (https) (optional)
 - exodus-gw dramatiq worker, for background tasks
 - postgres container
 - localstack container
+- exodus-lambda fakefront server (optional)
 - helpers for managing development certs
 
 Note: the sidecar proxy is only enabled when you instantiate the environment
@@ -60,6 +61,9 @@ Prerequisites
 - Your login sessions must make use of a systemd user manager.
 - You may need to install some packages. If so, the install script will list the needed
   packages for you.
+- If you want exodus-lambda fakefront to be enabled, you must have a copy of the
+  `exodus-lambda sources <https://github.com/release-engineering/exodus-lambda>`_
+  checked out as a sibling of the exodus-gw repository.
 
 
 Installation
@@ -132,7 +136,7 @@ the development environment.
    * - ``systemctl --user start exodus-gw.target``
      - Start all development services
 
-   * - ``journalctl --user '--unit=exodus-gw-*' -f``
+   * - ``journalctl --user '--unit=exodus-*' -f``
      - Watch logs of all services
 
    * - ``sudo cp ~/.config/exodus-gw-dev/ca.crt /etc/pki/ca-trust/source/anchors/exodus-gw-dev.crt``
@@ -165,6 +169,10 @@ the development environment.
 
    * - ``curl https://localhost:3377``
      - Sanity check for localstack
+
+   * - ``curl -I http://localhost:8049/_/cookie/test``
+     - Sanity check for fakefront; should give a 302 response, and does not require any
+       content to be loaded in the environment.
 
    * - ``scripts/localstack-init``
 

--- a/scripts/systemd/exodus-fakefront.service
+++ b/scripts/systemd/exodus-fakefront.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=exodus-lambda fakefront (fake cloudfront)
+Wants=network.target
+After=network-online.target exodus-gw-localstack.service
+
+[Service]
+EnvironmentFile=-%S/exodus-gw-dev/.env
+Environment=EXODUS_LAMBDA_SRC_PATH=%h/src/exodus-lambda
+Environment=EXODUS_AWS_ENDPOINT_URL=https://localhost:3377
+Environment=REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+Restart=on-failure
+
+ExecStart=/bin/sh -c "cd ${EXODUS_LAMBDA_SRC_PATH}; \
+ exec tox\
+ -e fakefront\
+"
+Type=exec
+
+[Install]
+WantedBy=exodus-gw.target

--- a/scripts/systemd/install
+++ b/scripts/systemd/install
@@ -11,6 +11,11 @@ use_sidecar(){
   host images.paas.redhat.com &>/dev/null
 }
 
+use_fakefront(){
+  # can exodus-lambda sources be found as a sibling to this repo?
+  test -f ../../../exodus-lambda/tox.ini
+}
+
 check_prereqs(){
   failed=0
   for cmd in podman sscg tox host hostname postgres; do
@@ -40,6 +45,12 @@ enable_units(){
   else
     echo "WARNING: sidecar image appears to be unavailable, cannot use HTTPS." 1>&2
   fi
+
+  if use_fakefront; then
+    systemctl --user enable $PWD/exodus-fakefront.service
+  else
+    echo "WARNING: exodus-lambda sources not found, fakefront was not enabled." 1>&2
+  fi
 }
 
 create_env_file(){
@@ -64,8 +75,11 @@ EXODUS_GW_SRC_PATH=$(realpath -L ../..)
 #EXODUS_GW_HTTP_PORT=8000
 #EXODUS_GW_HTTPS_PORT=8010
 
-# You'll have to change this too if you change the localstack port.
+# You'll have to change these too if you change the localstack port.
+# For exodus-gw:
 #EXODUS_GW_S3_ENDPOINT_URL=https://localhost:3377
+# For fakefront:
+#EXODUS_AWS_ENDPOINT_URL=https://localhost:3377
 
 # Dummy private key, enabling CDN redirect API.
 EXODUS_GW_CDN_PRIVATE_KEY_TEST="-----BEGIN RSA PRIVATE KEY-----
@@ -108,7 +122,7 @@ Suggested commands:
   systemctl --user start exodus-gw.target
 
   # Observe server logs
-  journalctl --user '--unit=exodus-gw-*' -f
+  journalctl --user '--unit=exodus-*' -f
 
   # Verify http server is working
   curl http://localhost:8000/healthcheck
@@ -129,6 +143,14 @@ END
 
   # Verify https server is working
   curl https://localhost:8010/healthcheck
+END
+  fi
+
+  if use_fakefront; then
+    cat <<END
+
+  # Verify fakefront is working
+  curl -I http://localhost:8049/_/cookie/test
 END
   fi
 }

--- a/scripts/systemd/restart
+++ b/scripts/systemd/restart
@@ -16,6 +16,10 @@ run(){
     systemctl --user stop exodus-gw-sidecar.service
   fi
 
+  if have_unit exodus-fakefront.service; then
+    systemctl --user stop exodus-fakefront.service
+  fi
+
   systemctl --user start exodus-gw.target
   echo "exodus-gw units are restarted!"
 }

--- a/scripts/systemd/uninstall
+++ b/scripts/systemd/uninstall
@@ -20,12 +20,14 @@ disable_units(){
   do_unit stop exodus-gw-db.service
   do_unit stop exodus-gw-localstack.service
   do_unit stop exodus-gw-sidecar.service
+  do_unit stop exodus-fakefront.service
   do_unit stop exodus-gw.target
   do_unit disable exodus-gw-uvicorn.service
   do_unit disable exodus-gw-worker.service
   do_unit disable exodus-gw-db.service
   do_unit disable exodus-gw-localstack.service
   do_unit disable exodus-gw-sidecar.service
+  do_unit disable exodus-fakefront.service
   do_unit disable exodus-gw.target
 }
 


### PR DESCRIPTION
When running the exodus-gw components locally it is convenient to also
run fakefront from exodus-lambda in the same way. This allows easy
access to published content without relying on DynamoDB table scans or
similar.