### PR TITLE
Upgrade exodus-gw to ubi9 [RHELDST-12689]

### DIFF
--- a/openshift/containers/exodus-gw/Dockerfile
+++ b/openshift/containers/exodus-gw/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 # Add sources
 COPY . /usr/local/src/exodus-gw/
@@ -8,7 +8,7 @@ RUN \
     # Install shadow-utils for adduser functionality
     microdnf -y install shadow-utils \
     # Install extra commands needed for build
-    && microdnf -y install python38 python38-devel gcc make \
+    && microdnf -y install python3 python3-devel gcc make \
     # Install packages needed for psycopg2 installation
     && microdnf -y install postgresql-devel \
     && cd /usr/local/src/exodus-gw \


### PR DESCRIPTION
It will use these python package:

- python3-3.9.10-2.el9.x86_64
- python3-devel-3.9.10-2.el9.x86_64