### PR TITLE
logging: prefix log messages with current actor

### DIFF
--- a/exodus_gw/dramatiq/broker.py
+++ b/exodus_gw/dramatiq/broker.py
@@ -14,6 +14,7 @@ from exodus_gw.dramatiq.consumer import Consumer
 from exodus_gw.dramatiq.middleware import (
     DatabaseReadyMiddleware,
     LocalNotifyMiddleware,
+    LogActorMiddleware,
     PostgresNotifyMiddleware,
     SchedulerMiddleware,
 )
@@ -45,6 +46,10 @@ class Broker(dramatiq.Broker):  # pylint: disable=abstract-method
         self.add_middleware(
             SchedulerMiddleware(self.__settings, self.__db_engine)
         )
+
+        # Enable automatic prefixing of log messages with actor names/identity
+        # such as "[commit <publish-id>] the log message..."
+        self.add_middleware(LogActorMiddleware())
 
         self.add_middleware(LocalNotifyMiddleware())
 

--- a/exodus_gw/dramatiq/middleware/__init__.py
+++ b/exodus_gw/dramatiq/middleware/__init__.py
@@ -1,5 +1,6 @@
 from .db_ready import DatabaseReadyMiddleware
 from .local_notify import LocalNotifyMiddleware
+from .log_actor import LogActorMiddleware
 from .pg_notify import PostgresNotifyMiddleware
 from .scheduler import SchedulerMiddleware
 
@@ -7,5 +8,6 @@ __all__ = [
     "LocalNotifyMiddleware",
     "PostgresNotifyMiddleware",
     "SchedulerMiddleware",
+    "LogActorMiddleware",
     "DatabaseReadyMiddleware",
 ]

--- a/exodus_gw/dramatiq/middleware/log_actor.py
+++ b/exodus_gw/dramatiq/middleware/log_actor.py
@@ -1,0 +1,56 @@
+import logging
+from functools import wraps
+from threading import local
+
+from dramatiq import Middleware
+
+
+class PrefixFilter(logging.Filter):
+    # A filter which will add an arbitrary thread-local prefix onto each message.
+
+    def __init__(self):
+        self.tls = local()
+        super().__init__()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = getattr(self.tls, "prefix", "") + record.msg
+        return True
+
+
+class LogActorMiddleware(Middleware):
+    """Middleware to prefix every log message with the current actor name."""
+
+    def __init__(self):
+        self.filter = PrefixFilter()
+
+    def after_process_boot(self, broker):
+        logging.getLogger().handlers[0].addFilter(self.filter)
+
+    def before_declare_actor(self, broker, actor):
+        actor.fn = self.wrap_fn_with_prefix(actor.fn)
+
+    def wrap_fn_with_prefix(self, fn):
+        # Given a function, returns a wrapped version of it which will adjust
+        # PrefixFilter's prefix around the function's invocation.
+
+        @wraps(fn)
+        def new_fn(*args, **kwargs):
+            # We want to show the function name (which is the actor name)...
+            prefix = fn.__name__
+
+            # If the actor takes a publish or task ID as an argument, we want
+            # to show that as well
+            for key in ("publish_id", "task_id"):
+                if key in kwargs:
+                    prefix = f"{prefix} {kwargs[key]}"
+                    break
+
+            prefix = f"[{prefix}] "
+
+            try:
+                self.filter.tls.prefix = prefix
+                return fn(*args, **kwargs)
+            finally:
+                self.filter.tls.prefix = ""
+
+        return new_fn


### PR DESCRIPTION
Add a new middleware which will arrange for all log messages produced
within an actor to be prefixed with at least the actor's name, plus
task/publish ID being processed where possible.

This ensures that every log message can be traced back to a particular
publish/task which makes it much easier to quickly find relevant logs,
without requiring the logging statements to explicitly log the task
being handled.

Here's an example of the impact of this change:

```
-Items successfully written
+[commit c3234df2-cdaf-4df1-aa1e-b360fd68f8a1] Items successfully written
```

This change was done in preparation for RHELDST-12449 which has some
requirements around logging.