### PR TITLE
exodus-gw.ini: use more appropriate log levels

### DIFF
--- a/exodus-gw.ini
+++ b/exodus-gw.ini
@@ -26,6 +26,6 @@ cdn_url = https://test3.cloudfront.net
 cdn_key_id = XXXXXXXXXXXXXX
 
 [loglevels]
-root = INFO
-exodus-gw = WARNING
+root = WARNING
+exodus-gw = INFO
 s3 = DEBUG

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,6 +7,7 @@ from exodus_gw.settings import load_settings
 def test_log_levels():
     """Ensure loggers are configured according to exodus-gw.ini."""
 
+    logging.getLogger().setLevel("INFO")
     logging.getLogger("old-logger").setLevel("DEBUG")
 
     loggers_init(load_settings())
@@ -15,8 +16,8 @@ def test_log_levels():
     assert logging.getLogger("old-logger").level == logging.DEBUG
 
     # Should set level of new loggers according to exodus-gw.ini.
-    assert logging.getLogger().level == logging.INFO
-    assert logging.getLogger("exodus-gw").level == logging.WARN
+    assert logging.getLogger().level == logging.WARN
+    assert logging.getLogger("exodus-gw").level == logging.INFO
     assert logging.getLogger("s3").level == logging.DEBUG
 
 


### PR DESCRIPTION
This config file is used both when running tests and from the exodus-gw
dev env.

The log levels requested here were presumably arbitrary for testing,
but they don't make sense for the dev env or in general: they set the
exodus-gw logger to *less* verbose than all other loggers, which is the
opposite of what we'd want in practice.

Flip it around so the root and exodus-gw loggers use more appropriate
levels (also matching the config we actually use for deployment), and
fix up the one affected test.