### PR TITLE
Fix test_publish.py::test_commit fails at UTC+2 or higher [RHELDST-13…

### DIFF
--- a/exodus_gw/migrations/versions/5bd0b38df850_.py
+++ b/exodus_gw/migrations/versions/5bd0b38df850_.py
@@ -1,0 +1,50 @@
+"""stop using timezone for column updated and deadline
+
+Revision ID: 5bd0b38df850
+Revises: 8b70b7e9c7fc
+Create Date: 2022-08-19 13:57:38.431351
+
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5bd0b38df850"
+down_revision = "8b70b7e9c7fc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DELETE FROM tasks")
+    op.execute("DELETE FROM publishes")
+
+    # recreate='always' to avoid "Cannot add a NOT NULL column with default value NULL"
+    # on sqlite < 3.32.0
+    recreate = (
+        "always"
+        if "sqlite" in os.environ.get("EXODUS_GW_DB_URL", "")
+        else "auto"
+    )
+
+    with op.batch_alter_table("tasks", recreate=recreate) as batch_op:
+        batch_op.alter_column("updated", type_=sa.DateTime(), nullable=True)
+        batch_op.alter_column("deadline", type_=sa.DateTime(), nullable=True)
+    with op.batch_alter_table("publishes", recreate=recreate) as batch_op:
+        batch_op.alter_column("updated", type_=sa.DateTime(), nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.alter_column(
+            "updated", type_=sa.DateTime(timezone=True), nullable=True
+        )
+        batch_op.alter_column(
+            "deadline", type_=sa.DateTime(timezone=True), nullable=True
+        )
+    with op.batch_alter_table("publishes") as batch_op:
+        batch_op.alter_column(
+            "updated", type_=sa.DateTime(timezone=True), nullable=True
+        )

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 
 from fastapi import HTTPException
 from sqlalchemy import (
@@ -28,7 +28,7 @@ class Publish(Base):
     )
     env = Column(String, nullable=False)
     state = Column(String, nullable=False)
-    updated = Column(DateTime(timezone=True))
+    updated = Column(DateTime())
     items = relationship(
         "Item", back_populates="publish", cascade="all, delete-orphan"
     )
@@ -67,7 +67,7 @@ class Publish(Base):
 
 @event.listens_for(Publish, "before_update")
 def publish_before_update(_mapper, _connection, publish):
-    publish.updated = datetime.now(timezone.utc)
+    publish.updated = datetime.utcnow()
 
 
 class Item(Base):

--- a/exodus_gw/models/service.py
+++ b/exodus_gw/models/service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import Column, DateTime, String, event
 from sqlalchemy.dialects.postgresql import UUID
@@ -13,10 +13,10 @@ class Task(Base):
     id = Column(UUID(as_uuid=True), primary_key=True)
     publish_id = Column(UUID(as_uuid=True))
     state = Column(String, nullable=False)
-    updated = Column(DateTime(timezone=True))
-    deadline = Column(DateTime(timezone=True))
+    updated = Column(DateTime())
+    deadline = Column(DateTime())
 
 
 @event.listens_for(Task, "before_update")
 def task_before_update(_mapper, _connection, task):
-    task.updated = datetime.now(timezone.utc)
+    task.updated = datetime.utcnow()

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -71,7 +71,7 @@ indefinitely.
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Dict, List, Union
 from uuid import UUID, uuid4
 
@@ -231,7 +231,7 @@ def commit_publish(
     objects from any of those publishes.
     """
 
-    now = datetime.now(timezone.utc)
+    now = datetime.utcnow()
 
     if isinstance(deadline, str):
         try:

--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from os.path import basename
 from typing import List
 
@@ -40,7 +40,7 @@ class Commit:
     @property
     def task_ready(self) -> bool:
         task = self.task
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         if task.state in (TaskStates.complete, TaskStates.failed):
             LOG.warning(
                 "Task %s in unexpected state, '%s'", task.id, task.state

--- a/exodus_gw/worker/scheduled.py
+++ b/exodus_gw/worker/scheduled.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import dramatiq
 from sqlalchemy.orm import Session
@@ -16,7 +16,7 @@ class Janitor:
     def __init__(self):
         self.settings = Settings()
         self.db = Session(bind=db_engine(self.settings))
-        self.now = datetime.now(timezone.utc)
+        self.now = datetime.utcnow()
 
     def run(self):
         self.fix_timestamps()

--- a/tests/worker/test_publish.py
+++ b/tests/worker/test_publish.py
@@ -1,12 +1,12 @@
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import mock
 
 from exodus_gw import models, worker
 
-NOW_UTC = datetime.now(timezone.utc)
+NOW_UTC = datetime.utcnow()
 
 
 def _task(publish_id):


### PR DESCRIPTION
…133]

This failure is due to SQLAlchemy losing timezone information when
using SQLite for unittests. When comparing the deadline in function
task_ready(),the task.deadline is not the same as the previous one
when it's created.

This patch will make unittests use UTC time to avoid using timezone.