### PR TITLE
Fix the migration failure on startup [RHELDST-13372]

### DIFF
--- a/exodus_gw/migrations/versions/5bd0b38df850_.py
+++ b/exodus_gw/migrations/versions/5bd0b38df850_.py
@@ -18,6 +18,7 @@ depends_on = None
 
 
 def upgrade():
+    op.execute("DELETE FROM items")
     op.execute("DELETE FROM tasks")
     op.execute("DELETE FROM publishes")
 


### PR DESCRIPTION
When both the "items" and "publishes" tables contain some data, then
only deleting the existing records in "publishes" table without cleaning
"items" table, it will violate the item's foreign key constraint
pointing back at publishes.

This commit adds the "items" table cleaning.