### PR TITLE
Fix the missing Content-Type when using links during publish [RHELDST…

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -46,15 +46,25 @@ class Publish(Base):
         ln_item_paths = [item.link_to for item in ln_items]
 
         # Store only necessary fields from matching items to conserve memory.
-        match = Bundle("match", Item.web_uri, Item.object_key)
+        match = Bundle(
+            "match", Item.web_uri, Item.object_key, Item.content_type
+        )
         matches = {
-            row.match["web_uri"]: row.match["object_key"]
+            row.match["web_uri"]: {
+                "object_key": row.match["object_key"],
+                "content_type": row.match["content_type"],
+            }
             for row in db.query(match).filter(Item.web_uri.in_(ln_item_paths))
         }
 
         for ln_item in ln_items:
-            ln_item.object_key = matches.get(ln_item.link_to)
-            if not ln_item.object_key:
+            match = matches.get(ln_item.link_to)
+
+            if (
+                not match
+                or not match.get("object_key")
+                or not match.get("content_type")
+            ):
                 raise HTTPException(
                     status_code=400,
                     detail=(
@@ -63,6 +73,9 @@ class Publish(Base):
                     )
                     % (ln_item.web_uri, ln_item.link_to),
                 )
+
+            ln_item.object_key = match.get("object_key")
+            ln_item.content_type = match.get("content_type")
 
 
 @event.listens_for(Publish, "before_update")

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -656,12 +656,14 @@ def test_commit_publish_linked_items(mock_commit, fake_publish, db):
         object_key="1" * 64,
         publish_id=fake_publish.id,
         link_to=None,  # It should be able to handle None/NULL link_to values...
+        content_type="some type",
     )
     item2 = Item(
         web_uri="/another/path",
         object_key="2" * 64,
         publish_id=fake_publish.id,
         link_to="",  # ...and empty string link_to values...
+        content_type="another type",
     )
     item3 = Item(
         web_uri="/some/different/path",
@@ -695,6 +697,12 @@ def test_commit_publish_linked_items(mock_commit, fake_publish, db):
     assert ln_item1.object_key == "1" * 64
     # Should've filled ln_item2's object_key with that of item2.
     assert ln_item2.object_key == "2" * 64
+
+    # Should've filled ln_item1's content_type with that of item1.
+    assert ln_item1.content_type == "some type"
+    # Should've filled ln_item2's content_type with that of item2.
+    assert ln_item2.content_type == "another type"
+
     # Should've created and sent task.
     assert isinstance(publish_task, Task)
 


### PR DESCRIPTION
…-13216]

Publishes using exodus-rsync & exodus-gw are supposed to automatically
populate a meaningful Content-Type on each published item.

Currently, if items are published via a symlink, no Content-Type is
assigned. This commit adds the copying of the link target's Contetn-Type
when resolving a link.