### PR TITLE
Add alembic_upgrade.py for DB migration [RHELDST-13374]

### DIFF
--- a/exodus_gw/alembic_upgrade.py
+++ b/exodus_gw/alembic_upgrade.py
@@ -1,0 +1,20 @@
+#
+# A wrapper for "alembic upgrade head" which will run upgrade operations to
+# the latest revision.
+#
+
+from .database import db_engine
+from .migrate import db_migrate
+from .settings import MigrationMode, load_settings
+
+
+def entry_point():
+    settings = load_settings()
+
+    settings.db_migration_mode = MigrationMode.upgrade
+    settings.db_migration_revision = "head"
+
+    engine = db_engine(settings)
+    db_migrate(engine, settings)
+
+    print("DB migration finished.")

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,13 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     install_requires=get_requirements(),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     project_urls={
         "Documentation": "https://release-engineering.github.io/exodus-gw",
+    },
+    entry_points={
+        "console_scripts": [
+            "exodus-gw-alembic-upgrade = exodus_gw.alembic_upgrade:entry_point"
+        ]
     },
 )

--- a/tests/test_alembic_upgrade.py
+++ b/tests/test_alembic_upgrade.py
@@ -1,0 +1,21 @@
+import mock
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from exodus_gw.alembic_upgrade import entry_point
+from exodus_gw.models import Publish
+
+
+@mock.patch("exodus_gw.database.db_engine")
+def test_entry_point_alembic_upgrade(mock_db_engine, unmigrated_db):
+    # Sanity check: at first there's no tables
+    with pytest.raises(OperationalError):
+        unmigrated_db.query(Publish).count()
+
+    mock_db_engine.return_value = unmigrated_db.get_bind()
+
+    # Migrate should succeed
+    entry_point()
+
+    # Now we can query stuff
+    assert unmigrated_db.query(Publish).count() == 0


### PR DESCRIPTION
Because a DB migration can take up to 15 minutes, we decide to decouple
it from the gunicorn initialization.

This commit adds a new script for calling alembic upgrade.