### PR TITLE
Improve use of batch write threads [RHELDST-13926]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -117,6 +117,10 @@ class Settings(BaseSettings):
     """Maximum write attempts to the DynamoDB table."""
     write_max_workers: int = 10
     """Maximum number of worker threads used in the DynamoDB batch writes."""
+    write_max_partitions: int = 3
+    """Maximum number of partitions (chunks of items) to begin writing at one
+    time.
+    """
 
     publish_timeout: int = 24
     """Maximum amount of time (in hours) between updates to a pending publish before


### PR DESCRIPTION
Previously, when writing items to DynamoDB, a single partition would be loaded and sumbitted to the thread pool executor, blocking until all items in the partition were completed.

This commit allows the number of partitions to be configured, meaning blocking only occurs once all item batches within n number of partitions are submitted to the executor.

Note that items are still only loaded per partition, so there should be no drastic memory usage increase. There is, however, correlation between number of partitions started and memory used due to the futures stored for each batch write but this should not normally be significant.