### PR TITLE
Make exodus-gw resilient against postgres connection drops [RHELDST-13928]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -108,6 +108,9 @@ class Settings(BaseSettings):
     the target revision when migrating the DB.
     """
 
+    db_session_max_tries: int = 3
+    """The maximum number of attempts to recreate a DB session within a request."""
+
     item_yield_size: int = 5000
     """Number of publish items to load from the service DB at one time."""
 


### PR DESCRIPTION
Exodus-gw now uses the sqlalchemy pool_pre_ping option to detect and recover from a broken DB connection at the beginning of the request. To accommodate for a broken DB connection within the request, exodus-gw wraps select endpoints in a "retry" decorator.