### PR TITLE
Enable pool_pre_ping on db connections [RHELDST-13928]

### DIFF
--- a/exodus_gw/database.py
+++ b/exodus_gw/database.py
@@ -17,4 +17,4 @@ def db_url(settings: Settings):
 
 
 def db_engine(settings: Settings):
-    return create_engine(db_url(settings))
+    return create_engine(db_url(settings), pool_pre_ping=True)


### PR DESCRIPTION
Exodus-gw now uses the SQLAlchemy pool_pre_ping option [1] to detect and recover from a broken DB connection [2] at the beginning of a request.

[1] https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping
[2] https://docs.sqlalchemy.org/en/14/core/pooling.html#dealing-with-disconnects