### PR TITLE
Fix typing errors on latest version of mypy

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -261,7 +261,7 @@ def load_settings() -> Settings:
     return settings
 
 
-def get_environment(env: str, settings: Settings = None):
+def get_environment(env: str, settings: Optional[Settings] = None):
     """Return the corresponding environment object for the given environment
     name.
     """


### PR DESCRIPTION
Fixes errors from two sources:

1) mypy previously applied an implicit Optional to default arguments
   declared as None. It no longer does this. Explained at
   https://github.com/hauntsaninja/no_implicit_optional#whats-going-on

2) In recent changes to test_db_session.py, code was added to
   dynamically set a call_count attribute onto a declared function to
   track whether it had been called earlier. There is no simple way to
   make the type checker understand this.

   Rewrite it slightly. All endpoints already have access to generic
   request and app scoped 'state' objects, so just use that instead of
   storing it on the function object. Also cleaner since the value does
   not have to be explicitly reset anywhere, since these state objects
   are already scoped appropriately.