### PR TITLE
Support metadata on S3 uploads [RHELDST-14181]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -49,6 +49,11 @@ class Settings(BaseSettings):
     and authorization).
     """
 
+    upload_meta_fields: Dict[str, str] = {}
+    """Permitted metadata field names for s3 uploads and their regex
+    for validation. E.g., "exodus-migration-md5": "^[0-9a-f]{32}$"
+    """
+
     log_config: Dict[str, Any] = {
         "version": 1,
         "incremental": True,

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -1,3 +1,5 @@
+import json
+
 from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
 
@@ -6,10 +8,28 @@ from exodus_gw.main import app
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
-async def test_head(mock_aws_client, auth_header):
+async def test_head(mock_aws_client, auth_header, monkeypatch):
     """Head request is delegated correctly to S3."""
 
-    mock_aws_client.head_object.return_value = {"ETag": "a1b2c3"}
+    monkeypatch.setenv(
+        "EXODUS_GW_UPLOAD_META_FIELDS",
+        json.dumps(
+            {
+                # md5sum of content being migrated
+                "exodus-migration-md5": "^[0-9a-f]{32}$",
+                # original source of migrated content
+                "exodus-migration-src": "^.{1,2000}$",
+            }
+        ),
+    )
+
+    mock_aws_client.head_object.return_value = {
+        "ETag": "a1b2c3",
+        "Metadata": {
+            "exodus-migration-md5": "94e19d5d30b26306167e9e7bae6b28fd",
+            "exodus-migration-src": "original/source",
+        },
+    }
 
     with TestClient(app) as client:
         r = client.head(
@@ -18,7 +38,12 @@ async def test_head(mock_aws_client, auth_header):
         )
 
     assert r.ok
-    assert r.headers["etag"] == "a1b2c3"
+    assert r.headers == {
+        "etag": "a1b2c3",
+        "x-amz-meta-exodus-migration-md5": "94e19d5d30b26306167e9e7bae6b28fd",
+        "x-amz-meta-exodus-migration-src": "original/source",
+        "content-length": "0",
+    }
 
 
 async def test_head_nonexistent_key(mock_aws_client, auth_header):

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -1,7 +1,6 @@
 import textwrap
 
 import mock
-import pytest
 from fastapi.testclient import TestClient
 
 from exodus_gw.aws.util import xml_response

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 from fastapi.testclient import TestClient
 
@@ -6,23 +7,45 @@ from exodus_gw.main import app
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
 
-async def test_full_upload(mock_aws_client, mock_request_reader, auth_header):
+async def test_full_upload(
+    mock_aws_client, mock_request_reader, auth_header, monkeypatch
+):
     """Uploading a complete object is delegated correctly to S3."""
+
+    monkeypatch.setenv(
+        "EXODUS_GW_UPLOAD_META_FIELDS",
+        '{"exodus-migration-md5": "^[0-9a-f]{32}$","exodus-migration-src": "^.{1,2000}$"}',
+    )
+
+    headers = {
+        **auth_header(roles=["test-blob-uploader"]),
+        "x-amz-meta-exodus-migration-md5": "94e19d5d30b26306167e9e7bae6b28fd",
+        "x-amz-meta-exodus-migration-src": "original/source",
+    }
 
     mock_request_reader.return_value = b"some bytes"
     mock_aws_client.put_object.return_value = {"ETag": "a1b2c3"}
 
     with TestClient(app) as client:
-        r = client.put(
-            "/upload/test/%s" % TEST_KEY,
-            headers=auth_header(roles=["test-blob-uploader"]),
-        )
+        r = client.put("/upload/test/%s" % TEST_KEY, headers=headers)
+
+    mock_aws_client.put_object.assert_called_with(
+        Bucket="my-bucket",
+        Key=TEST_KEY,
+        Body=mock.ANY,
+        ContentMD5="1B2M2Y8AsgTpgAmY7PhCfg==",
+        ContentLength=0,
+        Metadata={
+            "exodus-migration-md5": "94e19d5d30b26306167e9e7bae6b28fd",
+            "exodus-migration-src": "original/source",
+        },
+    )
 
     # It should succeed
     assert r.ok
 
-    # It should return the ETag
-    assert r.headers["ETag"] == "a1b2c3"
+    # It should return the correct headers
+    assert r.headers == {"etag": "a1b2c3", "content-length": "0"}
 
     # It should have an empty body
     assert r.content == b""
@@ -32,7 +55,7 @@ async def test_part_upload(mock_aws_client, mock_request_reader, auth_header):
     """Uploading part of an object is delegated correctly to S3."""
 
     mock_request_reader.return_value = b"best bytes"
-    mock_aws_client.upload_part.return_value = {"ETag": "aabbcc"}
+    mock_aws_client.upload_part.return_value = {"ETag": "a1b2c3"}
 
     with TestClient(app) as client:
         r = client.put(
@@ -41,10 +64,50 @@ async def test_part_upload(mock_aws_client, mock_request_reader, auth_header):
         )
 
     # It should succeed
-    assert r.status_code == 200
+    assert r.ok
 
-    # It should return the ETag
-    assert r.headers["ETag"] == "aabbcc"
+    # It should return the correct headers
+    assert r.headers == {"etag": "a1b2c3", "content-length": "0"}
 
     # It should have an empty body
     assert r.content == b""
+
+
+@pytest.mark.parametrize(
+    "metadata,err_msg",
+    [
+        ({"x-amz-meta-foo": "bar"}, "Invalid metadata field"),
+        (
+            {"x-amz-meta-exodus-migration-md5": "This is not a valid md5sum."},
+            "Invalid value for metadata field",
+        ),
+    ],
+    ids=["invalid field", "invalid value"],
+)
+async def test_upload_invalid_metadata(
+    metadata,
+    err_msg,
+    mock_aws_client,
+    mock_request_reader,
+    auth_header,
+    monkeypatch,
+):
+    """Uploading an object with invalid metadata raises an error"""
+
+    monkeypatch.setenv(
+        "EXODUS_GW_UPLOAD_META_FIELDS",
+        '{"exodus-migration-md5": "^[0-9a-f]{32}$"}',
+    )
+
+    mock_request_reader.return_value = b"some bytes"
+    mock_aws_client.put_object.return_value = {"ETag": "a1b2c3"}
+
+    with TestClient(app) as client:
+        r = client.put(
+            "/upload/test/%s" % TEST_KEY,
+            headers={**auth_header(roles=["test-blob-uploader"]), **metadata},
+        )
+
+    # It should fail with the correct error
+    assert r.status_code == 400
+    assert err_msg in r.text


### PR DESCRIPTION
When migrating content in the future, we plan to store information on uploaded objects. This commit allows users to set metadata via headers for fields defined in settings and HEAD requests will now return metadata stored with the object.