### PR TITLE
Fix CI for tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps=
 	-r requirements.txt
 	-r test-requirements.txt
 commands=pytest {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:static]
 commands=


### PR DESCRIPTION
New release of tox no longer allows usage of the term "whitelist" and instead requires "allowlist".