### PR TITLE
safety: do not block on PVE-2022-51668 for now [RHELDST-15252]

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,13 @@
+security:
+    ignore-cvss-severity-below: 4
+    ignore-cvss-unknown-severity: False
+    ignore-vulnerabilities:
+      51668:
+            # PVE-2022-51668, sqlalchemy str(engine.URL()) can leak password.
+            reason: >-
+              Our own code does not currently trigger any leaks.
+              We *should* fix the issue, but there is no stable release of
+              sqlalchemy 2 at time of writing.
+              See RHELDST-15252. 
+            expires: '2023-03-01'
+    continue-on-vulnerability-error: False


### PR DESCRIPTION
Our own code doesn't trigger any of the mentioned leaks. It also seems that an upgrade to sqlalchemy 2.x may require more effort than a typical upgrade, so a new issue has been filed for it.