### PR TITLE
Make commit_publish idempotent [RHELDST-15029]

### DIFF
--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -261,6 +261,15 @@ def commit_publish(
         )
 
     if db_publish.state != "PENDING":
+        # Check if there is already an associated task and, if so, return it rather than raise.
+        task = (
+            db.query(models.Task)
+            .filter(models.Task.publish_id == publish_id)
+            .first()
+        )
+        if task:
+            return task
+
         raise HTTPException(
             status_code=409,
             detail="Publish %s in unexpected state, '%s'"


### PR DESCRIPTION
When commit_publish is called multiple times or retried, it will now return the task to which the publish was previously assigned rather than raising an exception (because the publish is not currently "PENDING").