### PR TITLE
Make update_publish_items idempotent by no duplicating web_uri [RHELDST-15028]

### DIFF
--- a/exodus_gw/migrations/versions/6461bad8ed91_.py
+++ b/exodus_gw/migrations/versions/6461bad8ed91_.py
@@ -1,0 +1,28 @@
+"""add unique constraint on (publish_id, web_uri)
+
+Revision ID: 6461bad8ed91
+Revises: 5bd0b38df850
+Create Date: 2023-02-02 14:02:05.437573
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6461bad8ed91"
+down_revision = "5bd0b38df850"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("items") as batch_op:
+        batch_op.create_unique_constraint(
+            "items_publish_id_web_uri_key", ["publish_id", "web_uri"]
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("items") as batch_op:
+        batch_op.drop_constraint(
+            "items_publish_id_web_uri_key", type_="unique"
+        )

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -76,6 +76,7 @@ from typing import Dict, List, Union
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Body, HTTPException, Query
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, noload
 
 from .. import auth, deps, models, schemas, worker
@@ -193,8 +194,24 @@ def update_publish_items(
             % (db_publish.id, db_publish.state),
         )
 
-    for item in items:
-        db.add(models.Item(**item.dict(), publish_id=db_publish.id))
+    # Convert the list into dict and update each dict with a publish_id.
+    items_data = [
+        {**item.dict(), "publish_id": db_publish.id} for item in items
+    ]
+
+    LOG.debug("Adding %s items into '%s'", len(items_data), db_publish.id)
+
+    statement = insert(models.Item).values(items_data)
+
+    # Update all target table columns, except for the primary_key column.
+    update_dict = {c.name: c for c in statement.excluded if not c.primary_key}
+
+    update_statement = statement.on_conflict_do_update(
+        index_elements=["publish_id", "web_uri"],
+        set_=update_dict,
+    )
+
+    db.execute(update_statement)
 
     return {}
 


### PR DESCRIPTION
When update_publish_items is called, if the item's web_uri already exists on that publish, it will now update the item in db rather then adding a new item.