### PR TITLE
Add 'env' to publish queries [RHELDST-15336]

### DIFF
--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -177,7 +177,10 @@ def update_publish_items(
     db_publish = (
         db.query(models.Publish)
         .with_for_update()
-        .filter(models.Publish.id == publish_id)
+        .filter(
+            models.Publish.id == publish_id,
+            models.Publish.env == env.name,
+        )
         .first()
     )
 
@@ -251,7 +254,10 @@ def commit_publish(
     db_publish = (
         db.query(models.Publish)
         .with_for_update()
-        .filter(models.Publish.id == publish_id)
+        .filter(
+            models.Publish.id == publish_id,
+            models.Publish.env == env.name,
+        )
         .first()
     )
 
@@ -333,7 +339,6 @@ async def get_publish(
         db.query(models.Publish)
         .options(noload("items"))
         .filter(
-            # Since sub-environments share some resources, filter for env as well.
             models.Publish.id == publish_id,
             models.Publish.env == env.name,
         )

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -781,6 +781,23 @@ def test_commit_no_publish(auth_header):
     assert r.json() == {"detail": "No publish found for ID %s" % publish_id}
 
 
+def test_commit_env_mismatch(auth_header, fake_publish, db):
+    """Ensure we can't operate on publishes belonging to other environments"""
+
+    fake_publish.env = "pre"
+    db.add(fake_publish)
+    db.commit()
+
+    url = "/test/publish/%s/commit" % fake_publish.id
+    with TestClient(app) as client:
+        r = client.post(url, headers=auth_header(roles=["test-publisher"]))
+
+    assert r.status_code == 404
+    assert r.json() == {
+        "detail": "No publish found for ID %s" % fake_publish.id
+    }
+
+
 def test_get_publish_typical(auth_header, db):
     """GETing an existing publish returns a publish with no items."""
 


### PR DESCRIPTION
Previously, when querying publishes from the service db, we only filtered by publish IDs. This commit adds env to the query filter to ensure we're only manipulating publishes belonging to the service environment used.