### PR TITLE
Avoid sqlalchemy 2.x for now [RHELDST-15252]

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,8 @@ defusedxml
 uvicorn[standard]
 gunicorn
 psycopg2
-sqlalchemy
+# Need to do RHELDST-15252 in order to upgrade sqlalchemy
+sqlalchemy<2
 jsonschema
 alembic
 backoff


### PR DESCRIPTION
We already know that we aren't yet compatible with sqlalchemy 2.x and filed an issue to work on that.

Given that sqlalchemy 2.0.0 was recently released, our weekly dependency updates now try to make use of it and will fail CI. Request an older compatible version until we fix the compatibility issues.