### PR TITLE
Refactor and fix pip-compile

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,17 +12,15 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v2
        with:
-         # TODO: multi-version support
          python-version: 3.9
 
+     - name: Install tox
+       run: pip install tox
      
      - name: pip-compile
        uses: technote-space/create-pr-action@v2
        with:
-         EXECUTE_COMMANDS: |
-           pip install pip-tools
-           pip-compile -U --generate-hashes requirements.in
-           pip-compile -U --generate-hashes requirements.in test-requirements.in -o test-requirements.txt
+         EXECUTE_COMMANDS: tox -e pip-compile
          COMMIT_MESSAGE: 'chore: scheduled pip-compile'
          COMMIT_NAME: 'GitHub Actions'
          COMMIT_EMAIL: 'noreply@github.com'

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,15 @@ deps=
 commands=pytest {posargs}
 allowlist_externals=sh
 
+[testenv:pip-compile]
+deps = pip-tools
+basepython = python3.9
+skip_install = true
+skipsdist = true
+commands =
+    pip-compile -U --resolver=backtracking --generate-hashes requirements.in
+    pip-compile -U --resolver=backtracking --generate-hashes requirements.in test-requirements.in -o test-requirements.txt
+
 [testenv:static]
 commands=
 	mypy --install-types --non-interactive -p exodus_gw -p tests


### PR DESCRIPTION
Make the following changes to the pip-compile github action:

- run it via tox. Most of our repos using pip-compile already do this; the only reason it wasn't done here is that this was one of the earliest of our repos to adopt pip-compile and there was not yet an established convention.

  The primary advantage to this is that one can simply run "tox -e pip-compile" locally when needed.

- Use the backtracing resolver (which will be the default in 7.0.0). With the legacy resolver, pip-compile currently fails with:

      There are incompatible versions in the resolved dependencies:
        packaging>=22.0 (from black==23.1.0->-r test-requirements.in (line 2))
        packaging>=21.0 (from sphinx==6.1.3->-r test-requirements.in (line 10))
        packaging<22.0,>=21.0 (from safety==2.3.5->-r test-requirements.in (line 13))
        packaging (from pytest==7.2.1->-r test-requirements.in (line 9))

- remove one TODO comment which didn't seem to make sense, as there is no need for exodus-gw to support more than one python version.