### PR TITLE
Drop black from github actions CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     - id: black
       language_version: python3.8
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       language_version: python3.8

--- a/examples/exodus-sync
+++ b/examples/exodus-sync
@@ -58,7 +58,7 @@ def get_items(args):
     # Walk the source tree and get all items to be processed.
     items = []
 
-    for (dirpath, _, filenames) in os.walk(args.src):
+    for dirpath, _, filenames in os.walk(args.src):
         dirpath_rel = os.path.relpath(dirpath, args.src)
         for filename in filenames:
             src_path = os.path.join(dirpath, filename)

--- a/examples/update-config
+++ b/examples/update-config
@@ -17,6 +17,7 @@ def new_requests_session(args):
         session.cert = (args.cert, args.key)
     return session
 
+
 def check_service(args):
     session = new_requests_session(args)
 
@@ -118,7 +119,7 @@ def main():
     config = exodus_config.derive_exodus_config(eng_pp)
 
     post_url = os.path.join(args.exodus_gw_url, args.env, "deploy-config")
-    
+
     print("Submitting config to %s" % post_url)
 
     session = new_requests_session(args)
@@ -134,4 +135,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -113,7 +113,7 @@ def xml_response(operation: str, **kwargs) -> Response:
 
     status_code = kwargs.get("Code", 200)
 
-    for (key, value) in kwargs.items():
+    for key, value in kwargs.items():
         child = SubElement(root, key)
         child.text = str(value)
 

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -18,7 +18,6 @@ from .base import Base
 
 
 class Publish(Base):
-
     __tablename__ = "publishes"
 
     id = Column(
@@ -84,7 +83,6 @@ def publish_before_update(_mapper, _connection, publish):
 
 
 class Item(Base):
-
     __tablename__ = "items"
 
     id = Column(

--- a/exodus_gw/models/service.py
+++ b/exodus_gw/models/service.py
@@ -7,7 +7,6 @@ from .base import Base
 
 
 class Task(Base):
-
     __tablename__ = "tasks"
 
     id = Column(UUID(as_uuid=True), primary_key=True)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,5 +1,4 @@
 alabaster
-black
 coveralls
 mock
 mypy

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ allowlist_externals=sh
 commands=
 	mypy --install-types --non-interactive -p exodus_gw -p tests
 	sh -c 'pylint exodus_gw; test $(( $? & (1|2|4|32) )) = 0'
-	black --check .
 	isort --check .
 
 [testenv:cov]


### PR DESCRIPTION
"tox -e static" previously ran the black autoformatter using a version managed by pip-compile.

Problem: pre-commit also runs black, but this uses the version defined in the pre-commit config. If there are any differences in the black code style between the two versions of the tool, they will not both be able to pass.

This recently blocked dependency updates for this repo because a new release of black is available which has some incompatibilities with the version used by pre-commit.

Rather than trying to keep both versions in sync, it makes more sense to apply the tool in just one place; so let's drop it from tox & github actions and rely only on pre-commit.ci to both run the tool and manage the version of the tool.

This commit includes an update to the pre-commit hook versions so that pre-commit.ci will be able to pass.