### PR TITLE
Fix mypy error with latest versions of dependencies

### DIFF
--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -293,7 +293,7 @@ class Commit:
 
 @dramatiq.actor(time_limit=Settings().actor_time_limit)
 def commit(
-    publish_id: str, env: str, from_date: str, settings: Settings
+    publish_id: str, env: str, from_date: str, settings: Settings = Settings()
 ) -> None:
     actor_msg_id = CurrentMessage.get_current_message().message_id
     commit_obj = Commit(publish_id, env, from_date, actor_msg_id, settings)


### PR DESCRIPTION
With latest versions of all packages, mypy has started to complain:

      exodus_gw/routers/publish.py:304: error: Missing positional argument
          "settings" in call to "send" of "Actor"  [call-arg]

There is no actual type error here - we have dramatiq middleware to insert an instance of 'Settings' to any actor with a settings argument. However, mypy is not aware of that.

It can be easily fixed by declaring a default, so just do that. In practice we never expect the default to be used and this is only to help mypy.