### PR TITLE
Ensure exodus-gw image is updated [RHELDST-15305]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+  "enabled": true,
+  "enabledManagers": ["dockerfile", "github-actions"],
+  "dockerfile": {
+    "fileMatch": [".*Containerfile$"]
+  },
+  "automerge": true,
+  "stabilityDays": 3
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build docker image
       run: |
         docker --version
-        docker build . -f openshift/containers/exodus-gw/Dockerfile
+        docker build . -f openshift/containers/exodus-gw/Containerfile
 
     - name: Run bandit test
       run: tox -e bandit

--- a/openshift/containers/exodus-gw/Containerfile
+++ b/openshift/containers/exodus-gw/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:43246102cf37b0825786ca78e9a6e153c26d1a4241ddf53092e5b0ac18fe77bf
 
 # Add sources
 COPY . /usr/local/src/exodus-gw/
@@ -11,13 +11,14 @@ RUN \
     && microdnf -y install python3 python3-devel gcc make \
     # Install packages needed for psycopg2 installation
     && microdnf -y install postgresql-devel \
-    && cd /usr/local/src/exodus-gw \
+    # Ensure packages are up-to-date 
+    && microdnf -y update \
     # Install application itself
+    && cd /usr/local/src/exodus-gw \
     && pip3 install --require-hashes -r requirements.txt \
     && pip3 install --no-deps . \
     # Clean up unnecessary data
     && microdnf clean all && rm -rf /var/cache/yum && rm -rf /usr/local/src/exodus-gw
-
 
 # Run as a non-root user
 RUN adduser exodus-gw


### PR DESCRIPTION
To ensure exodus-gw has all available security patches, this commit;
- Locks UBI base image
- Adds renovate bot config, allowing automated base image updates
- Adds 'update' command to build

This commit also renames "Dockerfile" to "Containerfile" in openshift/containers/exodus-gw/.