### PR TITLE
Fix the ForeignKeyViolation by swapping the deletes [RHELDST-15252]

### DIFF
--- a/exodus_gw/worker/scheduled.py
+++ b/exodus_gw/worker/scheduled.py
@@ -107,7 +107,6 @@ class Janitor:
                     instance.id,
                     instance.updated,
                 )
-                self.db.delete(instance)
 
                 if isinstance(instance, Publish):
                     # Because publish items aren't loaded, they won't automatically be deleted.
@@ -115,6 +114,8 @@ class Janitor:
                     self.db.query(Item).filter(
                         Item.publish_id == instance.id
                     ).delete()
+
+                self.db.delete(instance)
 
 
 @dramatiq.actor(scheduled=True)


### PR DESCRIPTION
This commit swaps the order of deleting a publish object and deleting all of its items to fix the ForeignKeyViolation error.