### PR TITLE
Extend container's connection keep-alive to 15 seconds

### DIFF
--- a/openshift/containers/exodus-gw/Containerfile
+++ b/openshift/containers/exodus-gw/Containerfile
@@ -31,4 +31,5 @@ EXPOSE 8080
 ENTRYPOINT ["gunicorn", \
     "-k", "uvicorn.workers.UvicornWorker", \
     "--bind", "0.0.0.0:8080", \
+    "--keep-alive", "15", \
     "exodus_gw.main:app"]


### PR DESCRIPTION
It was found that connections were being dropped between platform-sidecar and exodus-gw. The default keep-alive is 2 seconds and there's evidence of requests exceeding this limit. This commit extends the max time limit for requests to 15 seconds.