### PR TITLE
Extend gw keep-alive for platform-sidecar idle time [RHELDST-17390]

### DIFF
--- a/openshift/containers/exodus-gw/Containerfile
+++ b/openshift/containers/exodus-gw/Containerfile
@@ -31,5 +31,5 @@ EXPOSE 8080
 ENTRYPOINT ["gunicorn", \
     "-k", "uvicorn.workers.UvicornWorker", \
     "--bind", "0.0.0.0:8080", \
-    "--keep-alive", "15", \
+    "--keep-alive", "30", \
     "exodus_gw.main:app"]


### PR DESCRIPTION
platform-sidecar is now deployed with a 15 second maxIdleTime for connections. This change gives more headroom for said connections.