### PR TITLE
Introduce cdn-access endpoint [RHELDST-17781]

### DIFF
--- a/exodus_gw/routers/cdn.py
+++ b/exodus_gw/routers/cdn.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import os
+import urllib.parse
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 
@@ -11,10 +12,10 @@ from botocore.utils import datetime2timestamp
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, HTTPException, Path, Query
 from fastapi.responses import Response
 
-from exodus_gw import schemas
+from exodus_gw import auth, schemas
 
 from .. import deps
 from ..settings import Environment, Settings
@@ -42,7 +43,7 @@ def rsa_signer(private_key: str, policy: bytes):
     return loaded_key.sign(policy, padding.PKCS1v15(), hashes.SHA1())  # type: ignore # nosec
 
 
-def encode_signature(data: bytes):
+def cf_b64(data: bytes):
     return (
         base64.b64encode(data)
         .replace(b"+", b"-")
@@ -78,7 +79,7 @@ def sign_url(url: str, timeout: int, env: Environment):
     signature = rsa_signer(env.cdn_private_key, policy)
     params = [
         "Expires=%s" % int(datetime2timestamp(expiration)),
-        "Signature=%s" % encode_signature(signature).decode("utf8"),
+        "Signature=%s" % cf_b64(signature).decode("utf8"),
         "Key-Pair-Id=%s" % env.cdn_key_id,
     ]
     separator = "&" if "?" in url else "?"
@@ -139,3 +140,108 @@ def cdn_redirect(
     return Response(
         content=None, headers={"location": signed_url}, status_code=302
     )
+
+
+@router.get(
+    "/{env}/cdn-access",
+    summary="Access",
+    status_code=200,
+    dependencies=[auth.needs_role("cdn-consumer")],
+    response_model=schemas.AccessResponse,
+)
+def cdn_access(
+    expire_days: int = Query(
+        # The following default is invalid and is set just to share a single
+        # validation path below for unset, too small and too large values.
+        default=-1,
+        description=(
+            "Desired expiration time, in days, for generated signatures.\n\n"
+            "It is mandatory to provide a value.\n\n"
+            "Cannot exceed a maximum value configured by the "
+            "server (typically 365 days)."
+        ),
+        example=30,
+    ),
+    settings: Settings = deps.settings,
+    env: Environment = deps.env,
+    call_context: auth.CallContext = deps.call_context,
+):
+    """Obtain signed cookies and other information needed for accessing
+    a specific CDN environment.
+
+    This endpoint may be used to look up the CDN origin server belonging
+    to a particular environment and to obtain long-term signed cookies
+    authorizing requests to that environment. The cookies returned by
+    this endpoint should be treated as a secret.
+
+    **Required roles**: `{env}-cdn-consumer`
+    """
+
+    if expire_days < 1 or expire_days > settings.cdn_max_expire_days:
+        raise HTTPException(
+            400,
+            detail=(
+                "An expire_days option from 1 "
+                f"to {settings.cdn_max_expire_days} must be provided"
+            ),
+        )
+
+    parsed_url = urllib.parse.urlparse(env.cdn_url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    # Note: it would be nice to generate separate cookies for /origin/*
+    # and /content/* resources, like the browser-oriented /_/cookie
+    # endpoint on exodus-lambda does, to help ensure all CDN access is
+    # locked down to those paths only.
+    #
+    # The problem with it is that CloudFront doesn't seem to accept
+    # multiple cookies provided by the client at once (seems undefined
+    # which one of the cookies is used). That means the client has to
+    # only provide the cookie which is relevant for the path being
+    # accessed.
+    #
+    # This is not an issue for a proper cookie engine as found
+    # in a browser or curl, which will implement that as a standard
+    # feature. But it is significantly onerous for some expected usage
+    # of these cookies: CDN edge servers cannot simply add
+    # a hardcoded Cookie header when contacting cloudfront but would
+    # instead have to branch based on which subtree is accessed.
+    #
+    # It seems as though it'd be unreasonable to require that complexity,
+    # so we're just going to generate a single cookie for "/*" and let
+    # the client provide one cookie for all requests.
+    resource = f"{base_url}/*"
+    expires = datetime.utcnow() + timedelta(days=expire_days)
+
+    policy = build_policy(resource, expires)
+    signature = rsa_signer(env.cdn_private_key, policy)
+    policy_encoded = cf_b64(policy).decode("utf-8")
+
+    components = {
+        "CloudFront-Key-Pair-Id": env.cdn_key_id,
+        "CloudFront-Policy": policy_encoded,
+        "CloudFront-Signature": cf_b64(signature).decode("utf8"),
+    }
+    cookie = "; ".join(f"{key}={value}" for (key, value) in components.items())
+
+    # Log info with sufficient detail so that all cookies in use can be traced
+    # back to the creating user.
+    username = (
+        call_context.client.serviceAccountId
+        or call_context.user.internalUsername
+        or "<unknown user>"
+    )
+    LOG.info(
+        "Generated cookie for: user=%s, key=%s, resource=%s, expires=%s, policy=%s",
+        username,
+        env.cdn_key_id,
+        resource,
+        expires,
+        policy_encoded,
+    )
+
+    return {
+        "url": base_url,
+        "expires": expires.isoformat(timespec="minutes") + "Z",
+        "cookie": cookie,
+    }

--- a/exodus_gw/routers/cdn.py
+++ b/exodus_gw/routers/cdn.py
@@ -116,7 +116,7 @@ redirect_common = dict(
     # overriding description here avoids repeating the main doc text
     # under both GET and HEAD methods.
     description="Identical to GET redirect, but for HEAD method.",
-    **redirect_common  # type: ignore
+    **redirect_common,  # type: ignore
 )
 @router.get(
     "/{env}/cdn/{url:path}", summary="Redirect (GET)", **redirect_common  # type: ignore

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -201,6 +201,28 @@ class Task(BaseModel):
         orm_mode = True
 
 
+class AccessResponse(BaseModel):
+    url: str = Field(
+        description="Base URL of this CDN environment.",
+        example="https://abc123.cloudfront.net",
+    )
+    expires: str = Field(
+        description=(
+            "Expiration time of access information included in this "
+            "response. ISO8601 UTC timestamp."
+        ),
+        example="2024-04-18T05:30Z",
+    )
+    cookie: str = Field(
+        description="A cookie granting access to this CDN environment.",
+        example=(
+            "CloudFront-Key-Pair-Id=K2266GIXCH; "
+            "CloudFront-Policy=eyJTdGF0ZW1lbn...; "
+            "CloudFront-Signature=kGkxpnrY9h..."
+        ),
+    )
+
+
 class MessageResponse(BaseModel):
     detail: str = Field(
         ..., description="A human-readable message with additional info."

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -201,6 +201,14 @@ class Settings(BaseSettings):
     cdn_signature_timeout: int = 60 * 30
     """Time (in seconds) signed URLs remain valid."""
 
+    cdn_max_expire_days: int = 365
+    """Maximum permitted value for ``expire_days`` option on
+    ``cdn-access`` endpoint.
+
+    Clients obtaining signed cookies for CDN using ``cdn-access`` will be
+    forced to renew their cookies at least this frequently.
+    """
+
     s3_pool_size: int = 3
     """Number of S3 clients to cache"""
 

--- a/tests/routers/test_cdn_access.py
+++ b/tests/routers/test_cdn_access.py
@@ -1,0 +1,79 @@
+from fastapi.testclient import TestClient
+from freezegun import freeze_time
+
+from exodus_gw.main import app
+
+
+@freeze_time("2023-04-20")
+def test_cdn_access_typical(
+    monkeypatch, dummy_private_key, auth_header, caplog
+):
+    """cdn-access endpoint returns valid access info in a typical scenario."""
+
+    monkeypatch.setenv("EXODUS_GW_CDN_PRIVATE_KEY_TEST", dummy_private_key)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/test/cdn-access?expire_days=60",
+            headers=auth_header(roles=["test-cdn-consumer"]),
+        )
+
+    # It should have succeeded
+    assert response.status_code == 200
+
+    # It should have generated exactly this output.
+    assert response.json() == {
+        "cookie": (
+            "CloudFront-Key-Pair-Id=XXXXXXXXXXXXXX; "
+            "CloudFront-Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cDovL2xvY2FsaG9zdDo4MDQ5LyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE2ODcxMzI4MDB9fX1dfQ__; "
+            "CloudFront-Signature=P-6pNRKHOOoK6~mKgK~bOb2LXLtepgJuFO4rwzUPKBrrTO2bBhmhAyIzA~W3rOFGWbd~IJ8ZHAKvYKXeg0e4-KI5lkPhM1uzyoqLdmewnfvKUB4TIesEms7JBBabSaiA6plc5cHLN08nql9TGUApBWYM6oycF-0tVBWr4AzBdxU_"
+        ),
+        "expires": "2023-06-19T00:00Z",
+        "url": "http://localhost:8049",
+    }
+
+    # It should have logged about the cookie generation.
+    expected_message = (
+        "Generated cookie for: user=fake-user, key=XXXXXXXXXXXXXX, "
+        "resource=http://localhost:8049/*, expires=2023-06-19 00:00:00, "
+        "policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cDovL2xvY2FsaG9zdDo4MDQ5LyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE2ODcxMzI4MDB9fX1dfQ__"
+    )
+    assert expected_message in caplog.text
+
+
+def test_cdn_access_unauthed(auth_header):
+    """cdn-access endpoint forbids usage if caller is missing needed role."""
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/test/cdn-access?expire_days=60",
+            headers=auth_header(roles=["some-unrelated-role"]),
+        )
+
+    # It should have been forbidden.
+    assert response.status_code == 403
+
+    # For this reason.
+    assert response.json() == {
+        "detail": "this operation requires role 'test-cdn-consumer'"
+    }
+
+
+def test_cdn_access_bad_expiry(monkeypatch, auth_header):
+    """cdn-access endpoint fails if caller requests expiration date out of range."""
+
+    monkeypatch.setenv("EXODUS_GW_CDN_MAX_EXPIRE_DAYS", "100")
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/test/cdn-access?expire_days=6000",
+            headers=auth_header(roles=["test-cdn-consumer"]),
+        )
+
+    # It should have failed
+    assert response.status_code == 400
+
+    # It should have generated exactly this output.
+    assert response.json() == {
+        "detail": "An expire_days option from 1 to 100 must be provided"
+    }


### PR DESCRIPTION
This endpoint allows users in the {env}-cdn-consumer role to generate cookies for accessing exodus-cdn with their preferred expiry date (up to a predefined maximum).

By having an API which can be used programmatically to generate cookies, exodus-cdn users can implement a fully automated workflow to rotate their cookies periodically. This helps shift responsibility for handling cookie expiry from exodus-cdn owners to exodus-cdn users.