### PR TITLE
dev-env: ensure role is set up for cdn-access [RHELDST-17781]

### DIFF
--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -40,6 +40,9 @@ com.redhat.api.platform:\n\
    test-config-deployer:\n\
     users:\n\
      byInternalUsername: [${USER}]\n\
+   test-cdn-consumer:\n\
+    users:\n\
+     byInternalUsername: [${USER}]\n\
 \nEND\n\
 "
 


### PR DESCRIPTION
The cdn-access endpoint won't be usable in the dev-env unless the current user is listed in the approprate role, so make sure to do that.