### PR TITLE
Log progress info during DynamoDB writes

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -182,7 +182,7 @@ class DynamoDB:
 
             raise RuntimeError("One or more writes were unsuccessful")
 
-        LOG.info("Items successfully %s", "deleted" if delete else "written")
+        LOG.debug("Items successfully %s", "deleted" if delete else "written")
 
     def write_config(self, config):
         request = self.create_config_request(config)

--- a/exodus_gw/worker/progress.py
+++ b/exodus_gw/worker/progress.py
@@ -1,0 +1,83 @@
+import logging
+from threading import Lock
+from time import monotonic
+
+LOG = logging.getLogger("exodus-gw")
+
+
+class ProgressLogger:
+    """A helper to generate progress logs during long-running processes."""
+
+    def __init__(self, message: str, items_total: int, interval: float = 5.0):
+        """Construct a progress logger.
+
+        Arguments:
+            message
+                A prefix for each generated log message.
+                Should indicate the operation taking place, e.g. "Writing items"
+
+            items_total
+                Total number of items expected to be processed.
+
+            interval
+                Minimum time in seconds between log messages.
+                The logger will not produce messages more frequently than
+                this.
+        """
+        self.message = message
+        self.lock = Lock()
+        self.items_total = items_total
+        self.items_processed = 0
+        self.start_time = monotonic()
+        self.last_write = 0.0
+        self.interval = interval
+
+    def adjust_total(self, increment: int):
+        """Add or subtract from the configured items_total.
+
+        This can be used to adjust the item total on the fly if
+        the earlier total was estimated and the estimate has
+        been updated.
+        """
+        with self.lock:
+            self.items_total += increment
+
+    def update(self, increment: int):
+        """Add given value to the count of processed items, possibly
+        triggering a log message.
+
+        This should be called repeatedly during a long-running operation
+        to produce log messages.
+        """
+
+        total = self.items_total
+        now = monotonic()
+
+        with self.lock:
+            self.items_processed += increment
+            processed = self.items_processed
+
+            # Prevents log messages from writing too frequently.
+            # But if we've just passed the expected total, we should always log.
+            if (
+                processed < self.items_total
+                and now - self.last_write < self.interval
+            ):
+                return
+
+            self.last_write = now
+
+        percent = processed / total * 100
+        runtime = now - self.start_time
+        items_per_second = processed / runtime if runtime > 0.01 else 0
+
+        # Example message:
+        # Writing phase 1 items: 775 (of 10000) [ 8% ] [6.9 p/sec]
+        LOG.info(
+            "%s: %s (of %s) [%2.0f%% ] [%2.1f p/sec]",
+            self.message,
+            processed,
+            total,
+            percent,
+            items_per_second,
+        )

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -126,7 +126,7 @@ def test_batch_write_item_limit(mock_boto3_client, fake_publish, caplog):
 
 @pytest.mark.parametrize("delete", [False, True], ids=["Put", "Delete"])
 def test_write_batch(delete, mock_boto3_client, fake_publish, caplog):
-    caplog.set_level(logging.INFO, logger="exodus-gw")
+    caplog.set_level(logging.DEBUG, logger="exodus-gw")
 
     mock_boto3_client.batch_write_item.return_value = {"UnprocessedItems": {}}
     mock_boto3_client.query.return_value = {

--- a/tests/worker/test_progress.py
+++ b/tests/worker/test_progress.py
@@ -1,0 +1,44 @@
+import logging
+
+from freezegun import freeze_time
+
+from exodus_gw.worker.progress import ProgressLogger
+
+
+def test_progress_logs_typical(caplog):
+    caplog.set_level(logging.INFO, logger="exodus-gw")
+
+    with freeze_time() as time:
+        logger = ProgressLogger(message="testing", items_total=100)
+
+        # Initial log
+        logger.update(5)
+
+        # More logs - should not generate anything because not enough
+        # time has passed
+        logger.update(5)
+        logger.update(5)
+
+        # Let time pass
+        time.tick(10)
+
+        # Now an update should do something
+        logger.update(5)
+
+        # Let time pass again
+        time.tick(10)
+
+        # Let's say we found some more items (total now 110)
+        logger.adjust_total(10)
+        logger.update(5)
+
+        # OK, let's finish up
+        logger.update(110 - 5 * 5)
+
+    # This is what it should have logged...
+    assert caplog.messages == [
+        "testing: 5 (of 100) [ 5% ] [0.0 p/sec]",
+        "testing: 20 (of 100) [20% ] [2.0 p/sec]",
+        "testing: 25 (of 110) [23% ] [1.2 p/sec]",
+        "testing: 110 (of 110) [100% ] [5.5 p/sec]",
+    ]

--- a/tests/worker/test_publish.py
+++ b/tests/worker/test_publish.py
@@ -311,7 +311,12 @@ def test_commit_write_queue_unfinished(
     commit_obj = worker.publish.Commit(
         fake_publish.id, fake_publish.env, NOW_UTC, task.id, settings
     )
-    bw = worker.publish._BatchWriter(commit_obj.dynamodb, settings)
+    bw = worker.publish._BatchWriter(
+        commit_obj.dynamodb,
+        settings,
+        len(fake_publish.items),
+        "test write items",
+    )
     # Simulate worker issue preventing write_batches from executing and
     # getting items from the queue.
     bw.write_batches = mock.MagicMock()


### PR DESCRIPTION
Previously during DynamoDB writes we only generated log messages such as "Items successfully written" per batch, which doesn't help much understanding the progress.

Let's add some new logging which makes it easier to track the progress and performance. An example of the new log messages generated during commit (maximum of one log message per 5 seconds):

    Writing phase 1 items: 775 (of 10000) [ 8% ] [6.9 p/sec]

Inspired by performance issues observed testing against localstack. These logs should make it easy to directly compare the performance (items per second) between localstack and each AWS environment.

The old log message still exists but was downgraded to DEBUG.