### PR TITLE
logging: add success/fail logs to authorization checks

### DIFF
--- a/tests/auth/test_roles.py
+++ b/tests/auth/test_roles.py
@@ -1,13 +1,23 @@
+import logging
+from dataclasses import dataclass
+
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import URL
 
 from exodus_gw.auth import (
     CallContext,
     ClientContext,
     UserContext,
+    caller_name,
     caller_roles,
     needs_role,
 )
+
+
+@dataclass
+class FakeRequest:
+    base_url: URL
 
 
 async def test_caller_roles_empty():
@@ -26,26 +36,81 @@ async def test_caller_roles_nonempty():
     assert (await caller_roles(ctx)) == set(["role1", "role2", "role3"])
 
 
-async def test_needs_role_success():
-    """needs_role succeeds when needed role is present."""
+async def test_caller_name_empty():
+    """caller_name returns a reasonable value for an unauthed context."""
+
+    assert (await caller_name(CallContext())) == "<anonymous user>"
+
+
+async def test_caller_name_simple():
+    """caller_name returns a reasonable value for a typical authed context."""
+
+    assert (
+        await caller_name(
+            CallContext(user=UserContext(internalUsername="shazza"))
+        )
+    ) == "user shazza"
+
+
+async def test_caller_name_multi():
+    """caller_name returns a reasonable value for a context having both user
+    and serviceaccount authentication info.
+
+    (Unclear if this can really happen.)
+    """
+
+    assert (
+        await caller_name(
+            CallContext(
+                user=UserContext(internalUsername="shazza"),
+                client=ClientContext(serviceAccountId="bottle-o"),
+            )
+        )
+    ) == "user shazza AND serviceaccount bottle-o"
+
+
+async def test_needs_role_success(caplog: pytest.LogCaptureFixture):
+    """needs_role succeeds and logs needed role is present."""
+
+    caplog.set_level(logging.INFO)
 
     fn = needs_role("better-role").dependency
 
-    # It should do nothing, successfully
-    await fn(roles=set(["better-role"]))
+    # It should succeed
+    await fn(
+        FakeRequest(URL("/endpoint")),
+        roles=set(["better-role"]),
+        caller_name="bazza",
+    )
+
+    # It should log about the successful auth
+    assert (
+        "Access permitted; path=/endpoint, user=bazza, role=better-role"
+        in caplog.text
+    )
 
 
-async def test_needs_role_fail():
-    """needs_role raises meaningful error when needed role is absent."""
+async def test_needs_role_fail(caplog: pytest.LogCaptureFixture):
+    """needs_role logs and raises meaningful error when needed role is absent."""
 
     fn = needs_role("best-role").dependency
 
     # It should raise an exception.
     with pytest.raises(HTTPException) as exc_info:
-        await fn(roles=set(["abc", "xyz"]))
+        await fn(
+            FakeRequest(URL("/endpoint")),
+            roles=set(["abc", "xyz"]),
+            caller_name="dazza",
+        )
 
     # It should use status 403 to tell the client they are unauthorized.
     assert exc_info.value.status_code == 403
 
     # It should give some hint as to the needed role.
     assert exc_info.value.detail == "this operation requires role 'best-role'"
+
+    # It should log about the authorization failure
+    assert (
+        "Access denied; path=/endpoint, user=dazza, role=best-role"
+        in caplog.text
+    )


### PR DESCRIPTION
If a user tries and fails to access an endpoint due to missing roles, according to the "events of interest" requirements we should probably be logging that.