### PR TITLE
logging: fix logged path always "/" during auth

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -112,7 +112,7 @@ def needs_role(rolename):
         if role not in roles:
             LOG.warning(
                 "Access denied; path=%s, user=%s, role=%s",
-                request.base_url.path,
+                request.url.path,
                 caller_name,
                 role,
                 extra={"event": "auth", "success": False},
@@ -123,7 +123,7 @@ def needs_role(rolename):
 
         LOG.info(
             "Access permitted; path=%s, user=%s, role=%s",
-            request.base_url.path,
+            request.url.path,
             caller_name,
             role,
             extra={"event": "auth", "success": True},

--- a/tests/auth/test_roles.py
+++ b/tests/auth/test_roles.py
@@ -17,7 +17,7 @@ from exodus_gw.auth import (
 
 @dataclass
 class FakeRequest:
-    base_url: URL
+    url: URL
 
 
 async def test_caller_roles_empty():

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -662,7 +662,11 @@ def test_commit_publish(deadline, auth_header, db, caplog):
 
     for message, event in [
         (
-            "Access permitted; path=/, user=user fake-user, role=test-publisher",
+            (
+                "Access permitted; "
+                "path=/test/publish/11224567-e89b-12d3-a456-426614174000/commit, "
+                "user=user fake-user, role=test-publisher"
+            ),
             "auth",
         ),
         (


### PR DESCRIPTION
I'm not sure why base_url was used here, but it was not the correct property. Per [1], request.base_url.path is simply always "/" and not the path actually being accessed.

request.url is the correct property to use here.

[1] https://github.com/encode/starlette/blob/15d9350eed9437bcb0683e2c24cd4cfbf985ed7e/starlette/requests.py#LL102C16-L102C16