### PR TITLE
Fix deploy-config tasks always crashing [RHELDST-18195]

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -199,4 +199,4 @@ class DynamoDB:
 
     def write_config(self, config):
         request = self.create_config_request(config)
-        self.batch_write(self.env_obj, request)
+        self.batch_write(request)


### PR DESCRIPTION
deploy-config has been broken since d2939b30c6fb14c, which changed the signature of DynamoDB.batch_write but didn't update one of the calls to that method, resulting in:

    TypeError: batch_write() takes 2 positional arguments but 3 were given

Additionally, as all tests of the deploy_config actor mocked out DynamoDB.batch_write, tests didn't detect the issue and instead incorrectly passed.

This commit fixes the crash and also changes one of the tests to work at a lower level (mocked boto) rather than mocking our DynamoDB helper class. This helps ensure the test would be able to detect similar problems in the future.