### PR TITLE
Log backoffs on EndpointConnectionErrors [RHELDST-18585]

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -140,6 +140,8 @@ class DynamoDB:
             backoff.expo,
             EndpointConnectionError,
             max_tries=self.settings.write_max_tries,
+            logger=LOG,
+            backoff_log_level=logging.DEBUG,
         )
         @backoff.on_predicate(
             wait_gen=backoff.expo,


### PR DESCRIPTION
The backoff library does not log retry attempts by default [1].

"By default, backoff and retry attempts are logged to the ‘backoff’
logger. By default, this logger is configured with a NullHandler, so
there will be nothing output unless you configure a handler.

[...]

It is also supported to specify a Logger (or LoggerAdapter) object
directly."

Now, the _batch_write backoff decorator has been configured to log
backoff events for any EndpointConnectionErrors encountered during
batch writes. This way, engineers can more easily identify when
retries due to EndpointConnectionErrors are attempted during batch
writes.

The backoff attempts are logged at DEBUG using the exodus-gw logger.

[1] https://pypi.org/project/backoff/