### PR TITLE
Log "login" events [RHELDST-19460]

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -130,3 +130,17 @@ def needs_role(rolename):
         )
 
     return Depends(check_roles)
+
+
+async def log_login(
+    request: Request,
+    roles: Set[str] = Depends(caller_roles),
+    caller_name: str = Depends(caller_name),
+):
+    LOG.info(
+        "Login: path=%s, user=%s, roles=%s",
+        request.url.path,
+        caller_name,
+        roles,
+        extra={"event": "login", "success": True},
+    )

--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -60,7 +60,7 @@ internal documentation for advice on which environment(s) you should be using.
 
 import backoff
 import dramatiq
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -69,6 +69,7 @@ from sqlalchemy.orm import Session
 from starlette.concurrency import run_in_threadpool
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from .auth import log_login
 from .aws.util import xml_response
 from .database import db_engine
 from .logging import loggers_init
@@ -89,6 +90,7 @@ app = FastAPI(
         deploy.openapi_tag,
         cdn.openapi_tag,
     ],
+    dependencies=[Depends(log_login)],
 )
 app.include_router(service.router)
 app.include_router(upload.router)


### PR DESCRIPTION
Our security standards require us to log "login" events.

Although exodus-gw does not technically provide a "login" endpoint, we have defined a login event as, "when platform-sidecar accepts a presented cert as valid during TLS handshake."

Unfortunately, the platform-sidecar logs do not seem to indicate whether a certificate has been provided with the request in question.

exodus-gw already produces an "auth" log containing the requested path, username, and roles when an endpoint that requires authorization has been requested. Though, exodus-gw also provides read-only endpoints which do not require authorization. It technically possible for a user to provide a cert (and for platform-sidecar to consider it valid) to endpoints which do not require authorization. A log was previously not produced in these instances.

Now, the user (or "anonymous user" if unauthenticated), roles (if any), and the requested path are now logged with each request to comply with our security standards. The path can be cross-referenced with the platform-sidecar logs, if/when needed.