### PR TITLE
Do not log unauthenticated logins [RHELDST-19460]

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -137,10 +137,11 @@ async def log_login(
     roles: Set[str] = Depends(caller_roles),
     caller_name: str = Depends(caller_name),
 ):
-    LOG.info(
-        "Login: path=%s, user=%s, roles=%s",
-        request.url.path,
-        caller_name,
-        roles,
-        extra={"event": "login", "success": True},
-    )
+    if caller_name != "<anonymous user>":
+        LOG.info(
+            "Login: path=%s, user=%s, roles=%s",
+            request.url.path,
+            caller_name,
+            roles,
+            extra={"event": "login", "success": True},
+        )

--- a/tests/routers/test_common.py
+++ b/tests/routers/test_common.py
@@ -102,6 +102,11 @@ def test_login_log(endpoint, user, roles, caplog, auth_header):
             "event": "login",
             "success": True,
         }
-        assert expected_log in [
-            json.loads(line) for line in caplog.text.splitlines()
-        ]
+        if user == "<anonymous user>":
+            assert expected_log not in [
+                json.loads(line) for line in caplog.text.splitlines()
+            ]
+        else:
+            assert expected_log in [
+                json.loads(line) for line in caplog.text.splitlines()
+            ]


### PR DESCRIPTION
The OpenShift readiness and/or liveness probes request the '/healthcheck' endpoint every every few seconds.

Requests from unauthenticated users need not be logged. Thus, to reduce the number of logs produced by exodus-gw, exodus-gw should only log requests from authenticated users. This will eliminate noisy "login" logs caused by the readiness/liveness probes.