### PR TITLE
Tweak 'safety' command to use JSON by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands=
 [testenv:safety]
 usedevelop=true
 commands=
-	safety check --full-report
+	safety check --output json {posargs}
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
JSON output shows better evidence that the dependency scanning is working properly. With --full-report we don't get a listing of the found packages and their versions.