### PR TITLE
Add max_backoff to dramatiq actors [RHEDLST-18193]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -148,7 +148,13 @@ class Settings(BaseSettings):
     """
 
     actor_time_limit: int = 30 * 60000
-    """Maximum amount of time (in milliseconds) actors may run."""
+    """Maximum amount of time (in milliseconds) actors may run. Defaults to 30
+    minutes.
+    """
+    actor_max_backoff: int = 5 * 60000
+    """Maximum amount of time (in milliseconds) actors may use while backing
+    off retries. Defaults to five (5) minutes.
+    """
 
     entry_point_files: List[str] = [
         "repomd.xml",

--- a/exodus_gw/worker/deploy.py
+++ b/exodus_gw/worker/deploy.py
@@ -13,7 +13,10 @@ from exodus_gw.settings import Settings
 LOG = logging.getLogger("exodus-gw")
 
 
-@dramatiq.actor(time_limit=Settings().actor_time_limit)
+@dramatiq.actor(
+    time_limit=Settings().actor_time_limit,
+    max_backoff=Settings().actor_max_backoff,
+)
 def complete_deploy_config_task(task_id: str):
     settings = Settings()
     db = Session(bind=db_engine(settings))
@@ -40,7 +43,10 @@ def complete_deploy_config_task(task_id: str):
     )
 
 
-@dramatiq.actor(time_limit=Settings().actor_time_limit)
+@dramatiq.actor(
+    time_limit=Settings().actor_time_limit,
+    max_backoff=Settings().actor_max_backoff,
+)
 def deploy_config(config: Dict[str, Any], env: str, from_date: str):
     settings = Settings()
     db = Session(bind=db_engine(settings))

--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -374,7 +374,10 @@ class Commit:
         asyncio.run(enricher.run())
 
 
-@dramatiq.actor(time_limit=Settings().actor_time_limit)
+@dramatiq.actor(
+    time_limit=Settings().actor_time_limit,
+    max_backoff=Settings().actor_max_backoff,
+)
 def commit(
     publish_id: str, env: str, from_date: str, settings: Settings = Settings()
 ) -> None:


### PR DESCRIPTION
Previously, actors had the ability to retry with exponential backoff. This commit adds the 'max_backoff' option to appropriate actors, preventing actors from backing off for intervals longer than determined by the actor_max_backoff setting (default 5 minutes).