### PR TITLE
Add logging handler to write to healthcheck file [RHELDST-19614]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -176,6 +176,9 @@ class Settings(BaseSettings):
     existing caches to expire and the newly deployed config to take effect.
     """
 
+    worker_health_filepath: str = "/tmp/exodus-gw-last-healthy"  # nosec - Bandit doesn't like that /tmp is used.
+    """The path to a file used to verify healthiness of a worker. Intended to be used by OCP"""
+
     worker_keepalive_timeout: int = 60 * 5
     """Background worker keepalive timeout, in seconds. If a worker fails to update its
     status within this time period, it is assumed dead.


### PR DESCRIPTION
To track the healthiness of workers in OCP, we'll probe for a specific
file, checking it's latest update time and restarting should a certain
time elapse since that update.

This commit implements the necessary mechanism for writing that file.
By using a custom logging handler, we implement an emit method to log
updates the healthcheck file. The location of the healthcheck file can
be configured via a new setting, "worker_health_filepath".