### PR TITLE
Add request/correlation IDs to log messages [RHELDST-18313]

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,3 +24,4 @@ importlib-metadata
 importlib-resources
 # safety requires packaging<22.0 and >=21.0.
 packaging==21.3
+asgi-correlation-id

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,6 +126,10 @@ anyio==3.7.1 \
     #   fastapi
     #   starlette
     #   watchfiles
+asgi-correlation-id==4.2.0 \
+    --hash=sha256:9d7dcfc2ed016f6e594fffd553788ac70129db7f92bb4dc268ab0b1a3284de5a \
+    --hash=sha256:bd3321a4022f38179db775d27c40cb45130ac9429d569cd59b5474cb2f65fb1b
+    # via -r requirements.in
 async-timeout==4.0.3 \
     --hash=sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f \
     --hash=sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028
@@ -1114,6 +1118,7 @@ starlette==0.27.0 \
     --hash=sha256:918416370e846586541235ccd38a474c08b80443ed31c578a418e2209b3eef91
     # via
     #   -r requirements.in
+    #   asgi-correlation-id
     #   fastapi
 typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -133,6 +133,10 @@ anyio==3.7.1 \
     #   httpcore
     #   starlette
     #   watchfiles
+asgi-correlation-id==4.2.0 \
+    --hash=sha256:9d7dcfc2ed016f6e594fffd553788ac70129db7f92bb4dc268ab0b1a3284de5a \
+    --hash=sha256:bd3321a4022f38179db775d27c40cb45130ac9429d569cd59b5474cb2f65fb1b
+    # via -r requirements.in
 astroid==2.15.6 \
     --hash=sha256:389656ca57b6108f939cf5d2f9a2a825a3be50ba9d589670f393236e0a03b91c \
     --hash=sha256:903f024859b7c7687d7a7f3a3f73b17301f8e42dfd9cc9df9d4418172d3e2dbd
@@ -1494,6 +1498,7 @@ starlette==0.27.0 \
     --hash=sha256:918416370e846586541235ccd38a474c08b80443ed31c578a418e2209b3eef91
     # via
     #   -r requirements.in
+    #   asgi-correlation-id
     #   fastapi
 stevedore==5.1.0 \
     --hash=sha256:8cc040628f3cea5d7128f2e76cf486b2251a4e543c7b938f58d9a377f6694a2d \

--- a/tests/app/test_db_session.py
+++ b/tests/app/test_db_session.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Optional
 
 import pytest
@@ -125,6 +124,8 @@ def test_db_rollback_on_raise_db(db):
 
         # Should fail since an exception was raised
         assert r.status_code == 500
+        assert r.json()["detail"] == "Internal server error"
+        assert len(r.headers["X-Request-ID"]) == 8
 
         # Should not have committed anything since exception was raised
         publishes = db.query(Publish).filter(Publish.id == TEST_UUID)

--- a/tests/routers/test_common.py
+++ b/tests/routers/test_common.py
@@ -85,19 +85,20 @@ def test_login_log(endpoint, user, roles, caplog, auth_header):
     with TestClient(app) as client:
         if roles:
             if endpoint == "/foo/publish":
-                client.post(
+                r = client.post(
                     endpoint, headers=auth_header(roles=["test-publisher"])
                 )
             else:
-                client.get(
+                r = client.get(
                     endpoint, headers=auth_header(roles=["test-publisher"])
                 )
         else:
-            client.get(endpoint)
+            r = client.get(endpoint)
         expected_log = {
             "level": "INFO",
             "logger": "exodus-gw",
             "time": "2023-07-28 13:24:03.596",
+            "request_id": r.headers["X-Request-ID"],
             "message": f"Login: path={endpoint}, user={user}, roles={roles}",
             "event": "login",
             "success": True,

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -270,6 +270,8 @@ def test_update_publish_items_no_uri(db, auth_header):
     # It should have failed with 400
     assert r.status_code == 400
     assert r.json() == {"detail": ["Value error, No URI: %s" % expected_item]}
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_existing_uri(db, auth_header):
@@ -373,6 +375,8 @@ def test_update_publish_items_invalid_item(db, auth_header):
             "Value error, No object key or link target: %s" % expected_item
         ]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_rejects_autoindex(db, auth_header):
@@ -408,6 +412,8 @@ def test_update_publish_items_rejects_autoindex(db, auth_header):
             "Value error, Invalid URI /foo/bar/.__exodus_autoindex: filename is reserved"
         ]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_link_and_key(db, auth_header):
@@ -450,6 +456,8 @@ def test_update_publish_items_link_and_key(db, auth_header):
             % expected_item
         ]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_link_content_type(db, auth_header):
@@ -490,6 +498,8 @@ def test_update_publish_items_link_content_type(db, auth_header):
             "Value error, Content type specified for link: %s" % expected_item
         ]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_invalid_object_key(db, auth_header):
@@ -531,6 +541,8 @@ def test_update_publish_items_invalid_object_key(db, auth_header):
             % expected_item
         ]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_absent_items_with_content_type(db, auth_header):
@@ -573,6 +585,8 @@ def test_update_publish_absent_items_with_content_type(db, auth_header):
             % expected_item
         ]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_invalid_content_type(db, auth_header):
@@ -612,6 +626,8 @@ def test_update_publish_items_invalid_content_type(db, auth_header):
     assert r.json() == {
         "detail": ["Value error, Invalid content type: %s" % expected_item]
     }
+    # It should include non-empty request header
+    assert len(r.headers["X-Request-ID"]) == 8
 
 
 def test_update_publish_items_no_publish(auth_header):
@@ -690,6 +706,7 @@ def test_commit_publish(deadline, auth_header, db, caplog):
                     "level": "INFO",
                     "logger": "exodus-gw",
                     "time": "2023-04-26 14:43:13.570",
+                    "request_id": r.headers["X-Request-ID"],
                     "message": message,
                     "event": event,
                     "success": True,

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -47,6 +47,9 @@ def test_healthcheck_worker_unhealthy(db):
         # Should give a generic message
         assert r.json() == {"detail": "background workers unavailable"}
 
+        # Code 500 responses should provide a request ID
+        assert len(r.headers["X-Request-ID"]) == 8
+
 
 async def test_whoami():
     # All work is done by fastapi deserialization, so this doesn't actually

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -38,12 +38,14 @@ async def test_head(mock_aws_client, auth_header, monkeypatch):
         )
 
     assert r.status_code == 200
-    assert r.headers == {
-        "etag": "a1b2c3",
-        "x-amz-meta-exodus-migration-md5": "94e19d5d30b26306167e9e7bae6b28fd",
-        "x-amz-meta-exodus-migration-src": "original/source",
-        "content-length": "0",
-    }
+    assert r.headers["etag"] == "a1b2c3"
+    assert (
+        r.headers["x-amz-meta-exodus-migration-md5"]
+        == "94e19d5d30b26306167e9e7bae6b28fd"
+    )
+    assert r.headers["x-amz-meta-exodus-migration-src"] == "original/source"
+    assert r.headers["content-length"] == "0"
+    assert r.headers["x-request-id"]
 
 
 async def test_head_nonexistent_key(mock_aws_client, auth_header):

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -4,7 +4,7 @@ import mock
 from fastapi.testclient import TestClient
 
 from exodus_gw.aws.util import xml_response
-from exodus_gw.deps import get_environment, get_s3_client, get_settings
+from exodus_gw.deps import get_environment, get_s3_client
 from exodus_gw.main import app
 from exodus_gw.routers.upload import multipart_upload
 from exodus_gw.settings import load_settings
@@ -140,6 +140,7 @@ async def test_bad_mpu_call(auth_header):
         b"<Endpoint>/upload/test/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c</Endpoint>"
         b"</Error>"
     )
+    assert r.headers["X-Request-ID"]
 
 
 async def test_abort_mpu(mock_aws_client, auth_header):

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import mock
 import pytest
 from fastapi.testclient import TestClient
@@ -45,7 +47,9 @@ async def test_full_upload(
     assert r.status_code == 200
 
     # It should return the correct headers
-    assert r.headers == {"etag": "a1b2c3", "content-length": "0"}
+    assert r.headers["etag"] == "a1b2c3"
+    assert r.headers["content-length"] == "0"
+    assert r.headers["x-request-id"]
 
     # It should have an empty body
     assert r.content == b""
@@ -67,7 +71,9 @@ async def test_part_upload(mock_aws_client, mock_request_reader, auth_header):
     assert r.status_code == 200
 
     # It should return the correct headers
-    assert r.headers == {"etag": "a1b2c3", "content-length": "0"}
+    assert r.headers["etag"] == "a1b2c3"
+    assert r.headers["content-length"] == "0"
+    assert r.headers["x-request-id"]
 
     # It should have an empty body
     assert r.content == b""


### PR DESCRIPTION
Previously, it was unclear which messages were logged for which request. Now, using the new 'request_id' field, one can match log messages that are associated with a particular request.