### PR TITLE
Ensure openapi files are copied to docs [RHELDST-19887]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -105,13 +105,6 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-
-# This dir contains the generated openapi spec and the static redoc-based
-# api.html for viewing. Copy it alongside the other docs.
-# Note: to enable sphinx linking to api.html, we also have an api.rst
-# and it's expected to be overwritten here. We depend on the implementation
-# detail that html_extra_path copying happens after .rst rendering.
-html_extra_path = ["openapi"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/scripts/gen-openapi
+++ b/scripts/gen-openapi
@@ -3,6 +3,7 @@
 # during publishing of docs.
 import json
 import os
+import shutil
 
 from exodus_gw.main import app
 
@@ -10,3 +11,6 @@ api = app.openapi()
 
 with open("docs/openapi/openapi.json", "wt") as f:
     json.dump(api, f)
+
+for f in os.listdir("docs/openapi"):
+    shutil.copy("docs/openapi/" + f, "docs/_build/html")

--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,8 @@ commands=
 [testenv:docs]
 use_develop=true
 commands=
-	python scripts/gen-openapi
 	sphinx-build -M html docs docs/_build
+	python scripts/gen-openapi
 
 [testenv:alembic-autogen]
 use_develop=true


### PR DESCRIPTION
Previously we relied on Sphinx to overwrite build files with those listed in html_extra_files, specifically api.html. However, for some reason, that is no longer happening. This commit adds a copy command to the gen-openapi script to ensure that the appropriate files are present in the final build.