### PR TITLE
Fix inability to launch dev-worker/dev-server on python3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,12 +58,14 @@ commands=
     python scripts/alembic-autogen {posargs}
 
 [testenv:dev-worker]
+basepython = python3.9
 use_develop=true
 passenv=EXODUS_GW*
 commands=
     dramatiq --watch exodus_gw exodus_gw.worker -p 1 {posargs}
 
 [testenv:dev-server]
+basepython = python3.9
 use_develop=true
 passenv=EXODUS_GW*
 commands=


### PR DESCRIPTION
The requirements.txt/test-requirements.txt files are pip-compiled using python 3.9, which means they are not necessarily expected to work for any other python versions. This is potentially a problem for the dev-{worker,server} envs, which did not declare any python version and therefore would use whatever was the default in the calling environment.

In practice, if the caller uses python3.11, installation has started to fail with a ResolutionImpossible error due to:

    The user requested greenlet==2.0.2
    gevent 23.9.1 depends on greenlet>=3.0rc3; platform_python_implementation == "CPython" and python_version >= "3.11"

(in other words: requirements.txt asks for greenlet==2.0.2 and gevent 23.9.1, this is possible on python 3.9, but on python 3.11 gevent 23.9.1 requests greenlet>=3.0rc3, making it impossible.)

In order for the requirements files to work reliably we have to use the same python version as used by pip-compile, so adjust config to do that.