### PR TITLE
Move correlation_id middleware and add validator [RHELDST-18313]

### DIFF
--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -58,6 +58,7 @@ If you are a client looking to make use of exodus-gw, consult your organization'
 internal documentation for advice on which environment(s) you should be using.
 """
 
+import re
 from uuid import uuid4
 
 import backoff
@@ -100,8 +101,6 @@ app.include_router(upload.router)
 app.include_router(publish.router)
 app.include_router(deploy.router)
 app.include_router(cdn.router)
-
-app.add_middleware(CorrelationIdMiddleware, generator=lambda: uuid4().hex[:8])
 
 
 @app.exception_handler(Exception)
@@ -219,3 +218,14 @@ def db_session(request: Request, call_next):
         return response
 
     return db_session_wrap()
+
+
+def request_id_validator(short_uuid: str):
+    return re.match(r"^[0-9a-f]{8}$", short_uuid)
+
+
+app.add_middleware(
+    CorrelationIdMiddleware,
+    generator=lambda: uuid4().hex[:8],
+    validator=request_id_validator,
+)

--- a/tests/app/test_request_id.py
+++ b/tests/app/test_request_id.py
@@ -1,0 +1,8 @@
+from uuid import uuid4
+
+from exodus_gw.main import request_id_validator
+
+
+def test_request_id_validator():
+    uuid = uuid4().hex[:8]
+    assert request_id_validator(uuid)


### PR DESCRIPTION
This commit moves the addition of CorrelationIdMiddleware to the end of main.py so that it's invoked first and the ID is added across the entire application. Additionally a custom correlation ID validator was added to prevent validation errors when the middleware encounters its own IDs, e.g., retries.