### PR TITLE
Update S3ClientWrapper to prevent retries [RHELDST-20355]

### DIFF
--- a/exodus_gw/aws/client.py
+++ b/exodus_gw/aws/client.py
@@ -26,7 +26,7 @@ class S3ClientWrapper:
             # We don't allow any retries - it's not possible since we're streaming
             # request bodies directly to S3, we don't buffer it anywhere, so we
             # can't send it more than once.
-            config=Config(retries={"max_attempts": 1}),
+            config=Config(retries={"total_max_attempts": 1}),
         )
 
     async def __aenter__(self):
@@ -46,7 +46,7 @@ class S3ClientWrapper:
 
     @staticmethod
     def no_redirects(**kwargs):
-        # An event handler for needs-s3.retry.* events which will disable implicit
+        # An event handler for needs-retry.s3.* events which will disable implicit
         # redirects between regions.
         #
         # The S3 client has a built-in feature where, if you do a request to a
@@ -79,6 +79,9 @@ class S3ClientWrapper:
         request_dict = kwargs.get("request_dict") or {}
         context = request_dict.get("context") or {}
         context["s3_redirected"] = True
+        # A newer version, S3RegionRedirectorv2, uses a different key. Let's add it too
+        # since we can't determine or control which version is used.
+        context["redirected"] = True
 
 
 class DynamoDBClientWrapper:

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -12,7 +12,7 @@ async def test_client_retries_disabled():
         # passing a config object with retries disabled
         client_call = aioboto3.Session().client.mock_calls[0]
         config = client_call.kwargs["config"]
-        assert config.retries == {"max_attempts": 1}
+        assert config.retries == {"total_max_attempts": 1}
 
 
 async def test_client_redirects_disabled():
@@ -41,5 +41,9 @@ async def test_client_redirects_disabled():
         handlers[0](request_dict=request_dict)
         assert request_dict == {
             "some": "fields",
-            "context": {"foo": "bar", "s3_redirected": True},
+            "context": {
+                "foo": "bar",
+                "s3_redirected": True,
+                "redirected": True,
+            },
         }


### PR DESCRIPTION
It was discovered that boto client configuration supports two retry attempt settings. The one used previously is not inclusive of the initial attempt so `"max_attempts": 1` means one retry will be attempted. This commit changes this setting to "total_max_attempts" because it is 1) preferred by the library and 2) inclusive of the initial attempt.

This directly addresses the intermittent UnseekableStreamErrors seen recently. These errors are only raised when boto attempts to retry S3 uploads, which we were unknowlingly commanding it to do.

Additionally in this commit, a key-value pair is added to the client's request to prevent redirects if/when botocore's newest redirector class is used.