### PR TITLE
dev env: use alternative dramatiq --watch backend

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ basepython = python3.9
 use_develop=true
 passenv=EXODUS_GW*
 commands=
-    dramatiq --watch exodus_gw exodus_gw.worker -p 1 {posargs}
+    dramatiq --watch exodus_gw --watch-use-polling exodus_gw.worker -p 1 {posargs}
 
 [testenv:dev-server]
 basepython = python3.9


### PR DESCRIPTION
I'm not exactly sure where the problem is, but for some time now when running dev-worker locally I'm seeing dramatiq decide to repeatedly reload as if some file is being continuously changed. This might be triggered by VS Code somehow.

The alternative polling-based backend seems perfectly stable, so use that instead.