### PR TITLE
Fix mismatch between sqlalchemy model and migrations

### DIFF
--- a/exodus_gw/models/dramatiq.py
+++ b/exodus_gw/models/dramatiq.py
@@ -25,7 +25,7 @@ class DramatiqMessage(Base):
     # Null means message is not yet assigned.
     # Not a foreign key since consumers can disappear while leaving
     # their messages behind.
-    consumer_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    consumer_id: Mapped[Optional[str]] = mapped_column(String)
 
     consumer = relationship(
         "DramatiqConsumer",
@@ -34,13 +34,13 @@ class DramatiqMessage(Base):
     )
 
     # Name of queue (e.g. "default" for most messages)
-    queue: Mapped[str] = mapped_column(String, nullable=False)
+    queue: Mapped[str] = mapped_column(String)
 
     # Name of actor
-    actor: Mapped[str] = mapped_column(String, nullable=False)
+    actor: Mapped[str] = mapped_column(String)
 
     # Full message body.
-    body: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    body: Mapped[Dict[str, Any]] = mapped_column(JSONB)
 
 
 class DramatiqConsumer(Base):
@@ -58,6 +58,4 @@ class DramatiqConsumer(Base):
     )
 
     # Last time this consumer reported itself to be alive.
-    last_alive: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False
-    )
+    last_alive: Mapped[datetime.datetime] = mapped_column(DateTime)

--- a/exodus_gw/models/service.py
+++ b/exodus_gw/models/service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import DateTime, String, event
 from sqlalchemy.orm import Mapped, mapped_column
@@ -11,10 +12,10 @@ class Task(Base):
     __tablename__ = "tasks"
 
     id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True)
-    publish_id: Mapped[str] = mapped_column(Uuid(as_uuid=False))
-    state: Mapped[str] = mapped_column(String, nullable=False)
-    updated: Mapped[datetime] = mapped_column(DateTime())
-    deadline: Mapped[datetime] = mapped_column(DateTime())
+    publish_id: Mapped[Optional[str]] = mapped_column(Uuid(as_uuid=False))
+    state: Mapped[str] = mapped_column(String)
+    updated: Mapped[Optional[datetime]] = mapped_column(DateTime())
+    deadline: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
 
 @event.listens_for(Task, "before_update")

--- a/exodus_gw/models/sqlite_compat.py
+++ b/exodus_gw/models/sqlite_compat.py
@@ -11,4 +11,4 @@ from sqlalchemy.ext.compiler import compiles
 
 @compiles(JSONB, "sqlite")
 def sqlite_jsonb(*_args, **_kwargs):
-    return "JSONB"
+    return "TEXT"

--- a/tests/migrate/test_migrations.py
+++ b/tests/migrate/test_migrations.py
@@ -1,5 +1,5 @@
 import pytest
-from alembic.command import downgrade, upgrade
+from alembic.command import check, downgrade, upgrade
 from alembic.config import Config
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
@@ -39,3 +39,36 @@ def test_migrations_up_down(tmpdir):
     # Sanity check: once again no tables
     with pytest.raises(OperationalError):
         session.execute(text("SELECT 1 FROM publishes"))
+
+
+def test_migration_completeness(tmpdir):
+    """Verify that running all migrations results in a schema which matches
+    the current sqlalchemy model.
+    """
+
+    db_file = str(tmpdir.join("migration-test.db"))
+    db_url = "sqlite:///%s" % db_file
+
+    engine = create_engine(db_url)
+    session = Session(bind=engine)
+
+    config = Config()
+    config.set_main_option("script_location", "exodus_gw:migrations")
+    config.set_main_option("sqlalchemy.url", db_url)
+
+    # Sanity check: we shouldn't have any tables yet
+    with pytest.raises(OperationalError):
+        session.execute(text("SELECT 1 FROM publishes"))
+
+    # Upgrade to latest works
+    upgrade(config, "head")
+
+    # Sanity check: now we should have some tables
+    session.execute(text("SELECT 1 FROM publishes"))
+
+    # If the migrations are complete, then 'check' here should succeed
+    # and do nothing.
+    #
+    # If the migrations are missing something from the model, this should
+    # detect it and raise an exception.
+    check(config)


### PR DESCRIPTION
While working on one issue I noticed that "alembic autogen" was not clean, i.e. it wanted to generate some migrations even though I'd not changed the model, indicating some drift between the two.

There were two issues, both fixed, and in both cases treating the migrations as correct and the model as the place to be fixed.

1. In cfa6812 (upgrade to sqlalchemy 2.0), the "nullable" state of various columns was unintentionally changed.

   Take tasks.deadline as an example. In our migrations, the column was always created as nullable=True. In the model, it was declared as a Mapped[datetime] with no specific 'nullable'; but per [A], that means it's derived from the type hint. Optional means nullable and non-Optional means not nullable, which makes sense. Hence that commit actually changed the column from nullable to not-nullable in the model, but didn't add any migration to do the same.

   While fixing this I also removed all 'nullable' from all columns so that we rely *solely* on the type hints; I think this is clearer than having two different ways of declaring whether something is nullable.

2. In 102733ca a migration was added to create a uniqueness constraint, but there was no attempt to add it to the model at all. Add the missing constraint now.

As well as the fixes, a new test was added which runs "alembic check" to prevent similar mistakes in the future.

The addition of that test required fixing one other unrelated problem: the JSONB hack in sqlite_compat was, for some reason, causing JSONB columns to end up in the schema as NUMERIC. That doesn't actually break sqlite since, as explained in the comment above, everything is text in sqlite anyway; but, starting from alembic 1.12.0 which released about a month ago, 'alembic check' detects this difference and so would fail the test.

Everything works fine if the hack is changed to instead declare the column as "TEXT"; the only reason it wasn't like that originally was because it seemed clearer if the sqlite schema would display the column as JSONB to indicate that it's not expected to contain arbitrary text.

[A] https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.mapped_column.params.nullable