### PR TITLE
refactor: move commit tasks into their own table

### DIFF
--- a/exodus_gw/migrations/test.py
+++ b/exodus_gw/migrations/test.py
@@ -1,0 +1,42 @@
+"""Utilities to assist in testing migrations."""
+import functools
+import os
+import typing
+
+
+def tested_by(data_fn: typing.Callable[[], None]):
+    """A decorator declaring a function which provides test data for
+    an upgrade or downgrade operation.
+
+    Usage:
+
+    >>> def my_data():
+    >>>    # alembic ops to populate some data
+    >>>    op.execute(...)
+    >>>
+    >>> @tested_by(my_data)
+    >>> def upgrade():
+    >>>    # the usual alembic ops to do an upgrade
+
+    When migrations are applied during test_migrations in this repo,
+    the data function will run prior to the upgrade/downgrade.
+
+    In all other contexts, the data function has no effect.
+
+    Note that using this decorator does not by itself verify that
+    any migrations of existing data work correctly, it only verifies
+    that migration can complete without crashing.
+    """
+
+    def decorator(fn: typing.Callable[[], None]):
+        @functools.wraps(fn)
+        def fn_with_data():
+            # Call the data function before the real migration function,
+            # but only if this env var is set.
+            if os.environ.get("EXODUS_GW_TESTING_MIGRATIONS") == "1":
+                data_fn()
+            fn()
+
+        return fn_with_data
+
+    return decorator

--- a/exodus_gw/migrations/versions/0d88322fe0b3_.py
+++ b/exodus_gw/migrations/versions/0d88322fe0b3_.py
@@ -1,0 +1,115 @@
+"""Split commit_tasks from tasks
+
+Revision ID: 0d88322fe0b3
+Revises: 6461bad8ed91
+Create Date: 2023-09-29 10:04:28.122074
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from exodus_gw.migrations.test import tested_by
+
+# revision identifiers, used by Alembic.
+revision = "0d88322fe0b3"
+down_revision = "6461bad8ed91"
+branch_labels = None
+depends_on = None
+
+
+def upgrade_testdata():
+    # Ensure that some publish and non-publish tasks exist,
+    # as both are expected to be split out to different tables.
+    op.bulk_insert(
+        sa.table(
+            "tasks",
+            sa.column("id", sa.Uuid(as_uuid=False)),
+            sa.column("publish_id", sa.Uuid(as_uuid=False)),
+            sa.column("state", sa.String()),
+        ),
+        [
+            # two tasks associated with a publish, should be
+            # moved to commit_tasks
+            {
+                "id": "fb870e73-ac62-4eb7-a75e-917b758a5d64",
+                "publish_id": "f7a38eb1-0d75-4245-a4ef-3dfd02d8129f",
+                "state": "NOT_STARTED",
+            },
+            {
+                "id": "c99702b6-b0a6-48e5-9cf2-9fabd65d3d72",
+                "publish_id": "e7c4d0b0-d158-49a3-a87a-3aeb7ce94e0d",
+                "state": "IN_PROGRESS",
+            },
+            # two tasks not associated with a publish
+            {
+                "id": "0f31777e-8171-4f83-99bb-0464d7f7cec8",
+                "publish_id": None,
+                "state": "NOT_STARTED",
+            },
+            {
+                "id": "b09f079a-8e5a-42d0-adc9-30a3a3c89d55",
+                "publish_id": None,
+                "state": "IN_PROGRESS",
+            },
+        ],
+    )
+
+
+@tested_by(upgrade_testdata)
+def upgrade():
+    op.create_table(
+        "commit_tasks",
+        sa.Column("id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.Column("publish_id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["id"],
+            ["tasks.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Add type column as nullable initially, then we'll populate the
+    # actual values and set non-nullable.
+    op.add_column(
+        "tasks",
+        sa.Column("type", sa.String(), nullable=True),
+    )
+    op.execute("UPDATE tasks SET type='task' WHERE publish_id IS NULL")
+    op.execute("UPDATE tasks SET type='commit' WHERE publish_id IS NOT NULL")
+
+    # It looks odd that we're doing a batch here with only one operation,
+    # but it's needed for sqlite compatibility
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.alter_column(
+            "type", existing_type=sa.String(), nullable=False
+        )
+
+    # With the commit_tasks table being created, we should now move over
+    # all publish_id values to that table.
+    op.execute(
+        """
+        INSERT INTO commit_tasks (id, publish_id)
+        SELECT id, publish_id FROM tasks WHERE tasks.type='commit'
+        """
+    )
+
+    op.drop_column("tasks", "publish_id")
+
+
+def downgrade():
+    # NOTE: there is no attempt to move publish_id info back into tasks
+    # during downgrade, the info is simply lost.
+    # We'll just wipe all tasks to avoid any incoherency.
+    op.execute("DELETE FROM tasks")
+
+    op.drop_column("tasks", "type")
+    op.add_column(
+        "tasks",
+        sa.Column(
+            "publish_id",
+            sa.Uuid(as_uuid=False),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.drop_table("commit_tasks")

--- a/exodus_gw/migrations/versions/be804e93d51d_.py
+++ b/exodus_gw/migrations/versions/be804e93d51d_.py
@@ -36,6 +36,10 @@ def upgrade():
 
 
 def downgrade():
+    # if restoring non-nullable publish_id, tasks with a null
+    # publish_id have to be dropped
+    op.execute("DELETE FROM tasks WHERE publish_id IS NULL")
+
     with op.batch_alter_table("tasks") as batch_op:
         batch_op.alter_column(
             "publish_id", existing_type=Uuid(), nullable=False

--- a/exodus_gw/models/__init__.py
+++ b/exodus_gw/models/__init__.py
@@ -2,7 +2,7 @@ from . import sqlite_compat  # noqa
 from .base import Base
 from .dramatiq import DramatiqConsumer, DramatiqMessage
 from .publish import Item, Publish
-from .service import Task
+from .service import CommitTask, Task
 
 __all__ = [
     "Base",
@@ -11,4 +11,5 @@ __all__ = [
     "Item",
     "Publish",
     "Task",
+    "CommitTask",
 ]

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -242,7 +242,7 @@ def commit_publish(
     deadline: Union[str, None] = Query(
         default=None, examples=["2022-07-25T15:47:47Z"]
     ),
-) -> models.Task:
+) -> models.CommitTask:
     """Commit an existing publish object.
 
     **Required roles**: `{env}-publisher`
@@ -295,8 +295,8 @@ def commit_publish(
     if db_publish.state != "PENDING":
         # Check if there is already an associated task and, if so, return it rather than raise.
         task = (
-            db.query(models.Task)
-            .filter(models.Task.publish_id == publish_id)
+            db.query(models.CommitTask)
+            .filter(models.CommitTask.publish_id == publish_id)
             .first()
         )
         if task:
@@ -323,7 +323,7 @@ def commit_publish(
     )
     db_publish.state = schemas.PublishStates.committing
 
-    task = models.Task(
+    task = models.CommitTask(
         id=msg.message_id,
         publish_id=msg.kwargs["publish_id"],
         state="NOT_STARTED",

--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session, lazyload
 
 from exodus_gw.aws.dynamodb import DynamoDB
 from exodus_gw.database import db_engine
-from exodus_gw.models import Item, Publish, Task
+from exodus_gw.models import CommitTask, Item, Publish
 from exodus_gw.schemas import PublishStates, TaskStates
 from exodus_gw.settings import Settings, get_environment
 
@@ -244,7 +244,11 @@ class Commit:
         return False
 
     def _query_task(self, actor_msg_id: str):
-        return self.db.query(Task).filter(Task.id == actor_msg_id).first()
+        return (
+            self.db.query(CommitTask)
+            .filter(CommitTask.id == actor_msg_id)
+            .first()
+        )
 
     def _query_publish(self, publish_id: str):
         publish = (

--- a/tests/migrate/test_migrations.py
+++ b/tests/migrate/test_migrations.py
@@ -6,12 +6,16 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 
-def test_migrations_up_down(tmpdir):
+def test_migrations_up_down(tmpdir, monkeypatch: pytest.MonkeyPatch):
     """Verify that "upgrade" and "downgrade" across all migrations can succeed.
 
     This doesn't verify functional correctness of migrations - only that the
     upgrade/downgrade functions can complete without crashing.
     """
+
+    # Setting this env var allows migrations to insert test data to the
+    # DB before/after upgrades/downgrades.
+    monkeypatch.setenv("EXODUS_GW_TESTING_MIGRATIONS", "1")
 
     db_file = str(tmpdir.join("migration-test.db"))
     db_url = "sqlite:///%s" % db_file

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 
 from exodus_gw import routers, schemas
 from exodus_gw.main import app
-from exodus_gw.models import Item, Publish, Task
+from exodus_gw.models import CommitTask, Item, Publish, Task
 from exodus_gw.settings import Environment, Settings, get_environment
 
 
@@ -746,7 +746,7 @@ def test_commit_publish_in_progress(mock_commit, fake_publish, db):
     # Simulate that this publish was already committed, assigned to
     # an in-progress task.
     fake_publish.state = schemas.PublishStates.committing
-    task = Task(
+    task = CommitTask(
         id="8d8a4692-c89b-4b57-840f-b3f0166148d2",
         publish_id=fake_publish.id,
         state=schemas.TaskStates.in_progress,

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -64,7 +64,7 @@ def test_get_task(db):
     publish_id = "48c67d99-5dd6-4939-ad1c-072639eee35a"
     task_id = "8d8a4692-c89b-4b57-840f-b3f0166148d2"
 
-    task = models.Task(
+    task = models.CommitTask(
         id=task_id,
         publish_id=publish_id,
         state="NOT_STARTED",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from exodus_gw.models import Item, Publish, Task
+from exodus_gw.models import CommitTask, Item, Publish
 
 
 def test_Item_init():
@@ -23,7 +23,7 @@ def test_publish_task_before_update(db):
     publish = Publish(id=publish_id, env="test", state="PENDING")
 
     task_id = "8d8a4692-c89b-4b57-840f-b3f0166148d2"
-    task = Task(
+    task = CommitTask(
         id=task_id,
         publish_id=publish_id,
         state="NOT_STARTED",

--- a/tests/worker/test_cleanup.py
+++ b/tests/worker/test_cleanup.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import pytest
 from sqlalchemy.orm.exc import ObjectDeletedError
 
-from exodus_gw.models import Item, Publish, Task
+from exodus_gw.models import CommitTask, Item, Publish
 from exodus_gw.schemas import PublishStates, TaskStates
 from exodus_gw.worker import cleanup
 
@@ -55,7 +55,7 @@ def test_cleanup_mixed(caplog, db):
         state=PublishStates.committed,
         updated=None,
     )
-    t1_missing_ts = Task(
+    t1_missing_ts = CommitTask(
         id=str(uuid.uuid4()),
         publish_id=p1_missing_ts.id,
         state=TaskStates.failed,
@@ -79,7 +79,7 @@ def test_cleanup_mixed(caplog, db):
         state=PublishStates.committing,
         updated=thirty_days_ago,
     )
-    t1_abandoned = Task(
+    t1_abandoned = CommitTask(
         id=str(uuid.uuid4()),
         publish_id=p1_abandoned.id,
         state=TaskStates.in_progress,
@@ -103,7 +103,7 @@ def test_cleanup_mixed(caplog, db):
         state=PublishStates.failed,
         updated=thirty_days_ago,
     )
-    t1_old = Task(
+    t1_old = CommitTask(
         id=str(uuid.uuid4()),
         publish_id=p1_old.id,
         state=TaskStates.failed,
@@ -122,7 +122,7 @@ def test_cleanup_mixed(caplog, db):
         state=PublishStates.pending,
         updated=half_day_ago,
     )
-    t1_recent = Task(
+    t1_recent = CommitTask(
         id=str(uuid.uuid4()),
         publish_id=p1_recent.id,
         state=TaskStates.complete,

--- a/tests/worker/test_publish.py
+++ b/tests/worker/test_publish.py
@@ -13,7 +13,7 @@ NOW_UTC = datetime.utcnow()
 
 
 def _task(publish_id):
-    return models.Task(
+    return models.CommitTask(
         id="8d8a4692-c89b-4b57-840f-b3f0166148d2",
         publish_id=publish_id,
         state="NOT_STARTED",


### PR DESCRIPTION
Previously the Task model had a publish_id column which was nullable, because some tasks relate to specific publishes (e.g. commit) and others do not (e.g. deploy-config).

For RHELDST-20490 I'd like to add some more columns which are specific to commit, but it's not really a good practice to dump all type-specific columns into a single table and allow them to be nullable. Inheritance can be used to instead have Task as the base class and CommitTask as a subclass adding additional fields, so let's do that.

The added migration includes usage of a recently added `tested_by` helper which allows tests to add data into the DB just before the migration runs. The migration tries to maintain all existing task objects correctly, and the test data helps ensure that this works. This also uncovered one (not very important) bug in an existing migration's "downgrade".