### PR TITLE
Set from_date from item update time [RHELDST-20491]

### DIFF
--- a/exodus_gw/migrations/versions/fbac38695a01_.py
+++ b/exodus_gw/migrations/versions/fbac38695a01_.py
@@ -1,0 +1,86 @@
+"""Add updated timestamp to items
+
+Revision ID: fbac38695a01
+Revises: 1d51b80e64ba
+Create Date: 2023-10-04 13:41:25.588710
+
+"""
+from datetime import datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+from exodus_gw.migrations.test import tested_by
+
+# revision identifiers, used by Alembic.
+revision = "fbac38695a01"
+down_revision = "1d51b80e64ba"
+branch_labels = None
+depends_on = None
+
+
+# Basic declaration of items table, pre and post migration.
+def columns_pre():
+    return [
+        sa.column("id", sa.Uuid(as_uuid=False)),
+        sa.column("web_uri", sa.String()),
+        sa.column("object_key", sa.String()),
+        sa.column("publish_id", sa.Uuid(as_uuid=False)),
+    ]
+
+
+items_pre = sa.table("items", *columns_pre())
+
+items_post = sa.table(
+    "items", *(columns_pre() + [sa.column("updated", sa.DateTime())])
+)
+
+
+def upgrade_testdata():
+    publish_id = "f7a38eb1-0d75-4245-a4ef-3dfd02d8129f"
+
+    op.bulk_insert(
+        items_pre,
+        [
+            {
+                "id": "6d9ae1af-0f26-4491-8f05-762d0f3c540d",
+                "publish_id": publish_id,
+                "web_uri": "/foo-updated",
+                "object_key": "a1b2c3",
+            },
+            {
+                "id": "68f376fb-4f36-4efc-bed7-a289c4fe43f1",
+                "publish_id": publish_id,
+                "web_uri": "/bar-updated",
+                "object_key": "a1b2c3",
+            },
+        ],
+    )
+
+
+@tested_by(upgrade_testdata)
+def upgrade():
+    # Add updated initially as nullable, fill in any missing values, then make
+    # it not-nullable.
+    op.add_column(
+        "items",
+        sa.Column("updated", sa.DateTime(), nullable=True),
+    )
+
+    # Any items which existed at time of migration will have their updated
+    # timestamp set to the time at which the migration runs.
+    op.execute(
+        items_post.update()
+        .where(items_post.c.updated == None)
+        .values(updated=datetime.utcnow())
+    )
+
+    # Now everything has a value, make it not nullable.
+    with op.batch_alter_table("items") as batch_op:
+        batch_op.alter_column(
+            "updated", existing_type=sa.DateTime(), nullable=False
+        )
+
+
+def downgrade():
+    op.drop_column("items", "updated")

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -28,7 +28,9 @@ NOW_UTC = str(datetime.now(timezone.utc))
                                     "S": "0bacfc5268f9994065dd858ece3359fd"
                                     "7a99d82af5be84202b8e84c2a5b07ffa"
                                 },
-                                "from_date": {"S": NOW_UTC},
+                                # Note these timestamps come from the canned values
+                                # on fake_publish.items
+                                "from_date": {"S": "2023-10-04 03:52:00"},
                                 "content_type": {"S": None},
                             }
                         }
@@ -41,7 +43,7 @@ NOW_UTC = str(datetime.now(timezone.utc))
                                     "S": "e448a4330ff79a1b20069d436fae9480"
                                     "6a0e2e3a6b309cd31421ef088c6439fb"
                                 },
-                                "from_date": {"S": NOW_UTC},
+                                "from_date": {"S": "2023-10-04 03:52:01"},
                                 "content_type": {"S": None},
                             }
                         }
@@ -54,7 +56,7 @@ NOW_UTC = str(datetime.now(timezone.utc))
                                     "S": "3f449eb3b942af58e9aca4c1cffdef89"
                                     "c3f1552c20787ae8c966767a1fedd3a5"
                                 },
-                                "from_date": {"S": NOW_UTC},
+                                "from_date": {"S": "2023-10-04 03:52:02"},
                                 "content_type": {"S": None},
                             }
                         }
@@ -70,7 +72,7 @@ NOW_UTC = str(datetime.now(timezone.utc))
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/some/path"},
-                                "from_date": {"S": NOW_UTC},
+                                "from_date": {"S": "2023-10-04 03:52:00"},
                             }
                         }
                     },
@@ -78,7 +80,7 @@ NOW_UTC = str(datetime.now(timezone.utc))
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/other/path"},
-                                "from_date": {"S": NOW_UTC},
+                                "from_date": {"S": "2023-10-04 03:52:01"},
                             }
                         }
                     },
@@ -86,7 +88,7 @@ NOW_UTC = str(datetime.now(timezone.utc))
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/to/repomd.xml"},
-                                "from_date": {"S": NOW_UTC},
+                                "from_date": {"S": "2023-10-04 03:52:02"},
                             }
                         }
                     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+from datetime import datetime
 from typing import List
 
 import dramatiq
@@ -189,16 +190,19 @@ def fake_publish():
             web_uri="/some/path",
             object_key="0bacfc5268f9994065dd858ece3359fd7a99d82af5be84202b8e84c2a5b07ffa",
             publish_id=publish.id,
+            updated=datetime(2023, 10, 4, 3, 52, 0),
         ),
         models.Item(
             web_uri="/other/path",
             object_key="e448a4330ff79a1b20069d436fae94806a0e2e3a6b309cd31421ef088c6439fb",
             publish_id=publish.id,
+            updated=datetime(2023, 10, 4, 3, 52, 1),
         ),
         models.Item(
             web_uri="/to/repomd.xml",
             object_key="3f449eb3b942af58e9aca4c1cffdef89c3f1552c20787ae8c966767a1fedd3a5",
             publish_id=publish.id,
+            updated=datetime(2023, 10, 4, 3, 52, 2),
         ),
     ]
     yield publish


### PR DESCRIPTION
All items written to DynamoDB are sorted by from_date.

Up to now, we have always taken the from_date from the time at which the commit task was enqueued. This means if two publishes would try to update the same path at the same time, whoever commits last "wins".

Those semantics are in fact not the most useful, which was exposed once realistic Pulp usage occurred. The problem is that it allows a sequence like the following:

1. Repo publishes within exodus-gw publish A.

2. Repo publishes again, within exodus-gw publish B.

3. Publish B is committed.
     => new state: repodata from (2) is available on CDN (which also contains packages added at step (1))

4. Publish A is committed.
     => new state: repodata from (1) is available on CDN.
          BUG! repodata has effectively gone backwards, "unpublishing" whatever was added in step (2).

It makes more sense to take the from_date from the time at which each individual item was updated. This makes the above scenario work as desired:

1. Repo publishes within exodus-gw publish A.

2. Repo publishes again, within exodus-gw publish B.

3. Publish B is committed.
     => new state: repodata from (2) is available on CDN. (which also contains packages added at step (1))

4. Publish A is committed.
     => inserts DynamoDB items for the repodata from (1), but since
          these have an earlier from_date than what's already in the DB,
          there is effectively no impact on the repodata.

This change ensures that, if multiple publishes are updating the same path, everything keeps moving strictly forward even if commits are done in the reverse order from updates.

Note that the commit actor still retains a 'from_date' because that's also used to query exodus-config while running, and it's still reasonable to use the commit time for that.