### PR TITLE
Pass S3 error codes back to client [RHELDST-20675]

### DIFF
--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -111,7 +111,7 @@ def xml_response(operation: str, **kwargs) -> Response:
     """
     root = Element(operation)
 
-    status_code = kwargs.get("Code", 200)
+    status_code = kwargs.pop("status_code", 200)
 
     for key, value in kwargs.items():
         child = SubElement(root, key)

--- a/tests/routers/upload/test_head.py
+++ b/tests/routers/upload/test_head.py
@@ -52,7 +52,15 @@ async def test_head_nonexistent_key(mock_aws_client, auth_header):
     """Head handles 404 responses correctly."""
 
     mock_aws_client.head_object.side_effect = ClientError(
-        {"Error": {"Code": "404"}},
+        {
+            "Error": {
+                "Code": "NoSuchKey",
+                "Message": "The resource you requested does not exist",
+            },
+            "ResponseMetadata": {
+                "HTTPStatusCode": 404,
+            },
+        },
         "HeadObject",
     )
 
@@ -63,21 +71,3 @@ async def test_head_nonexistent_key(mock_aws_client, auth_header):
         )
 
     assert r.status_code == 404
-
-
-async def test_head_logs_error(mock_aws_client, auth_header, caplog):
-    """Head logs unexpected errors correctly."""
-
-    mock_aws_client.head_object.side_effect = ClientError(
-        {"Error": {"Code": "501"}},
-        "HeadObject",
-    )
-
-    with TestClient(app) as client:
-        r = client.head(
-            "/upload/test/%s" % TEST_KEY,
-            headers=auth_header(roles=["test-blob-uploader"]),
-        )
-
-    assert r.status_code == 501
-    assert "HEAD to S3 failed" in caplog.text


### PR DESCRIPTION
Any error responses from S3 would be previously caught by our generic exception handler and turned into a 500 internal server error.

We shouldn't do that, instead we should be giving the real error codes from upstream S3 back to the exodus-gw client so that:

- if the error is the client's fault, they can see the reason for that (e.g. BadDigest)

- if the error is of a type expected to happen during the course of normal S3 usage, make sure the client can see that error properly so that they can retry as normal (e.g. SlowDown)

- errors from S3 don't drag down the SLI of our service

This commit adds a new exception handler which passes back any upload errors using the proper status and error response.

Note that head_object already had special handling for this, specifically for 404 errors, since we've always used that to determine whether an object exists. There is no need for that to have special handling, as the desired behavior (pass back any errors from S3) is the same for all of the upload endpoints. Hence that special handling has been removed, along with an associated test.