### PR TITLE
Improve DB connection logging

### DIFF
--- a/tests/worker/test_cleanup.py
+++ b/tests/worker/test_cleanup.py
@@ -25,7 +25,12 @@ def test_cleanup_noop(caplog, db):
     cleanup()
 
     # It should not have done anything, other than log this.
-    assert caplog.messages == ["Scheduled cleanup has completed"]
+    messages = [
+        record.message
+        for record in caplog.records
+        if record.name == "exodus-gw"
+    ]
+    assert messages == ["Scheduled cleanup has completed"]
 
 
 def test_cleanup_mixed(caplog, db):
@@ -180,7 +185,12 @@ def test_cleanup_mixed(caplog, db):
     assert t1_recent.state == TaskStates.complete
 
     # It should have logged exactly what it did.
-    assert sorted(caplog.messages) == sorted(
+    messages = [
+        record.message
+        for record in caplog.records
+        if record.name == "exodus-gw"
+    ]
+    assert sorted(messages) == sorted(
         [
             ####################################################
             # Fixed timestamps


### PR DESCRIPTION
We are required to log outbound connections.
To achieve this for DB connections we've currently enabled sqlalchemy connection pool logging at DEBUG level, but that includes a lot of annoying log spam as well.

sqlalchemy has an events system which allows us to explicitly hook into connection events. Let's use that so we can arrange for connection logs at INFO level without having to enable logging of all other connection pool events.