### PR TITLE
Improve boto/AWS logging

### DIFF
--- a/exodus_gw/aws/client.py
+++ b/exodus_gw/aws/client.py
@@ -4,6 +4,20 @@ import aioboto3
 import boto3.session
 from botocore.config import Config
 
+from .log import add_loggers
+
+
+def boto_session(*args, **kwargs) -> boto3.session.Session:
+    out = boto3.session.Session(*args, **kwargs)
+    add_loggers(out)
+    return out
+
+
+def aioboto_session(*args, **kwargs) -> aioboto3.Session:
+    out = aioboto3.Session(*args, **kwargs)
+    add_loggers(out)
+    return out
+
 
 class S3ClientWrapper:
     """Helper class to obtain preconfigured S3 clients.
@@ -18,7 +32,7 @@ class S3ClientWrapper:
         Note: Session creation will fail if provided profile cannot be found.
         """
 
-        session = aioboto3.Session(profile_name=profile)
+        session = aioboto_session(profile_name=profile)
 
         self._client_context = session.client(
             "s3",
@@ -95,7 +109,7 @@ class DynamoDBClientWrapper:
         Note: Session creation will fail if provided profile cannot be found.
         """
 
-        session = boto3.session.Session(profile_name=profile)
+        session = boto_session(profile_name=profile)
 
         self._client = session.client(
             "dynamodb",

--- a/exodus_gw/aws/log.py
+++ b/exodus_gw/aws/log.py
@@ -1,0 +1,68 @@
+"""AWS logging utilities."""
+
+import logging
+from typing import Any, Optional, Union
+
+import aioboto3
+import boto3.session
+from botocore.awsrequest import AWSPreparedRequest, AWSResponse
+
+REQUEST_LOG = logging.getLogger("exodus-gw.aws-request")
+RESPONSE_LOG = logging.getLogger("exodus-gw.aws-response")
+
+
+def request_logger(request: AWSPreparedRequest, **_kwargs):
+    # Callback for logging requests being sent to AWS.
+    REQUEST_LOG.info(
+        "%s %s",
+        request.method,
+        request.url,
+        extra={
+            "event": {
+                "method": request.method,
+                "url": request.url,
+            }
+        },
+    )
+
+
+def response_logger(
+    response: Optional[tuple[AWSResponse, Any]],
+    request_dict: dict[str, Any],
+    caught_exception: Optional[Exception],
+    **_kwargs
+):
+    # Callback for logging responses from AWS.
+    url = response[0].url if response else request_dict["url"]
+    event = {
+        "method": request_dict["method"],
+        "url": url,
+    }
+    summary = "<unknown result>"
+
+    if caught_exception:
+        summary = event["exception"] = repr(caught_exception)
+    elif response:
+        event["status"] = response[0].status_code
+        summary = str(event["status"])
+
+    RESPONSE_LOG.info(
+        "%s %s: %s",
+        request_dict["method"],
+        url,
+        summary,
+        extra={"event": event},
+    )
+
+
+def add_loggers(session: Union[boto3.session.Session, aioboto3.Session]):
+    """Add some custom loggers onto a boto session."""
+
+    # Log just before we send requests.
+    session.events.register("before-send.*", request_logger)
+
+    # It's not entirely obvious, but needs-retry is actually the
+    # best event for logging responses (rather than e.g. after-call).
+    # It is the only event which gets access to both the request and
+    # the response, and is also called both on success and failure.
+    session.events.register("needs-retry.*", response_logger)

--- a/exodus_gw/worker/autoindex.py
+++ b/exodus_gw/worker/autoindex.py
@@ -6,12 +6,12 @@ import tempfile
 from time import monotonic
 from typing import AsyncGenerator, BinaryIO, Generator, Optional
 
-import aioboto3
 from botocore.exceptions import ClientError
 from repo_autoindex import ContentError, Fetcher, autoindex
 from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 
+from exodus_gw.aws.client import aioboto_session
 from exodus_gw.models import Item, Publish
 from exodus_gw.settings import Environment, Settings, get_environment
 
@@ -269,7 +269,7 @@ class AutoindexEnricher:
             extra={"event": "publish"},
         )
 
-        session = aioboto3.Session(profile_name=self.env.aws_profile)
+        session = aioboto_session(profile_name=self.env.aws_profile)
 
         async with session.client(
             "s3",

--- a/tests/aws/test_logs.py
+++ b/tests/aws/test_logs.py
@@ -1,0 +1,104 @@
+import io
+from dataclasses import dataclass
+from typing import Optional
+
+import boto3.session
+import botocore
+import pytest
+from boto3.session import Session
+from botocore.awsrequest import AWSPreparedRequest, AWSResponse
+
+from exodus_gw.aws.client import boto_session
+
+
+class RawResponse(io.BytesIO):
+    # An object of the (undocumented?) type used by
+    # AWSResponse to hold HTTP response body.
+    def stream(self, **_kwargs):
+        while contents := self.read():
+            yield contents
+
+
+@dataclass
+class AWSResponder:
+    # A callable to respond to AWS requests, if installed as a
+    # before-send event handler.
+    status_code: int = 200
+    body: bytes = b""
+    exception: Optional[Exception] = None
+
+    def __call__(self, request: AWSPreparedRequest, **_kwargs):
+        if self.exception:
+            raise self.exception
+
+        return AWSResponse(
+            url=request.url,
+            status_code=self.status_code,
+            headers={},
+            raw=RawResponse(self.body),
+        )
+
+
+def test_client_logs_requests(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """Boto clients log AWS requests and responses."""
+
+    # boto3.session.Session is usually mocked by an autouse fixture.
+    # That's good, as we want to ensure all tests by default have no
+    # chance of accidentally using real AWS.
+    #
+    # But the mock does not trigger realistic boto events, so is
+    # incapable of realistic testing of the logging behavior.
+    #
+    # This test therefore patches back in the original Session
+    # so we can construct a *real* client, though we will install
+    # custom event handlers on it to prevent it doing any real
+    # requests.
+    monkeypatch.setattr(boto3.session, "Session", Session)
+
+    session = boto_session(
+        aws_access_key_id="fake",
+        aws_secret_access_key="fake",
+        aws_session_token="fake",
+        region_name="fake",
+    )
+
+    s3 = session.client("s3")
+
+    # Install our own object to generate fake responses before sending them.
+    # This is an event handler, installed *after* the logging event handler,
+    # so the logging handler will see requests as if they happened for real.
+    responder = AWSResponder()
+    s3.meta.events.register_last("before-send.*", responder)
+
+    # Successful case:
+    obj_url = "https://test-bucket.s3.fake.amazonaws.com/test-key"
+    s3.head_object(Bucket="test-bucket", Key="test-key")
+
+    assert caplog.messages == [
+        f"HEAD {obj_url}",
+        f"HEAD {obj_url}: 200",
+    ]
+    caplog.clear()
+
+    # Graceful error case (still a valid HTTP response):
+    responder.status_code = 501
+    with pytest.raises(botocore.exceptions.ClientError):
+        s3.head_object(Bucket="test-bucket", Key="test-key")
+
+    assert caplog.messages == [
+        f"HEAD {obj_url}",
+        f"HEAD {obj_url}: 501",
+    ]
+    caplog.clear()
+
+    # Ungraceful error case (no HTTP response):
+    responder.exception = RuntimeError("simulated error")
+    with pytest.raises(RuntimeError):
+        s3.create_multipart_upload(Bucket="test-bucket", Key="test-key")
+
+    assert caplog.messages == [
+        f"POST {obj_url}?uploads",
+        f"POST {obj_url}?uploads: RuntimeError('simulated error')",
+    ]


### PR DESCRIPTION
We're required to log outbound connections.
Currently, for requests to AWS we achieve this by bumping the botocore.endpoint logger to DEBUG level.

This works, but it includes a lot of unwanted detail including some things which probably shouldn't go into the logs, such as request signatures.

Let's arrange for some logging of the requests via event handlers under our control. This allows us to log exactly what's needed. Request and response logs are both added, using different loggers so they can be toggled independently.