### PR TITLE
docs: tweak language regarding items on "Get Publish"

### DIFF
--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -456,11 +456,9 @@ async def get_publish(
     env: Environment = deps.env,
     db: Session = deps.db,
 ):
-    """Return existing publish object from database using given publish ID.
+    """Return an existing publish object from database using the given publish ID.
 
-    Because we don't have a use case for them and implementation would
-    be non-trivial, items belonging to the publish are not loaded/returned.
-    This is achieved using the noload() query option.
+    For performance reasons, the returned item list is always empty.
     """
 
     db_publish = (


### PR DESCRIPTION
This API doesn't load/return the "items" list on a publish. The way this was explained before was not appropriate for a user-oriented doc.

The reference to noload() in particular is a very inappropriate detail since a user of the exodus-gw API does not need to know or care that SQLAlchemy is used, or even that an SQL-based DB is used.

(We probably should have made this API just not return the 'items' element at all, instead of an empty list, but it's a bit late for that now.)