### PR TITLE
docs: improve/fix various examples

### DIFF
--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -141,13 +141,15 @@ router = APIRouter(tags=[openapi_tag["name"]])
                 "application/json": {
                     "examples": [
                         {
-                            "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-                            "env": "prod",
-                            "links": {
-                                "self": "/prod/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
-                                "commit": "/prod/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
-                            },
-                            "items": [],
+                            "value": {
+                                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                                "env": "live",
+                                "links": {
+                                    "self": "/live/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                                    "commit": "/live/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
+                                },
+                                "items": [],
+                            }
                         }
                     ]
                 }
@@ -432,13 +434,15 @@ def commit_publish(
                 "application/json": {
                     "examples": [
                         {
-                            "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-                            "env": "live",
-                            "links": {
-                                "self": "/live/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
-                                "commit": "/live/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
-                            },
-                            "items": [],
+                            "value": {
+                                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                                "env": "live",
+                                "links": {
+                                    "self": "/live/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                                    "commit": "/live/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
+                                },
+                                "items": [],
+                            }
                         }
                     ]
                 }

--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -65,16 +65,18 @@ def healthcheck_worker(
                 "application/json": {
                     "examples": [
                         {
-                            "client": {
-                                "roles": ["someRole", "anotherRole"],
-                                "authenticated": True,
-                                "serviceAccountId": "clientappname",
-                            },
-                            "user": {
-                                "roles": ["viewer"],
-                                "authenticated": True,
-                                "internalUsername": "someuser",
-                            },
+                            "value": {
+                                "client": {
+                                    "roles": ["someRole", "anotherRole"],
+                                    "authenticated": True,
+                                    "serviceAccountId": "clientappname",
+                                },
+                                "user": {
+                                    "roles": ["viewer"],
+                                    "authenticated": True,
+                                    "internalUsername": "someuser",
+                                },
+                            }
                         }
                     ]
                 }

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -176,12 +176,17 @@ class Task(BaseModel):
     updated: Optional[datetime] = Field(
         None,
         description="DateTime of last update to this task. None if never updated.",
+        examples=["2019-08-24T14:15:22Z"],
     )
     deadline: Optional[datetime] = Field(
-        None, description="DateTime at which this task should be abandoned."
+        None,
+        description="DateTime at which this task should be abandoned.",
+        examples=["2019-08-24T18:15:22Z"],
     )
     links: Dict[str, str] = Field(
-        {}, description="""URL links related to this task."""
+        {},
+        description="""URL links related to this task.""",
+        examples=[{"self": "/task/497f6eca-6276-4993-bfeb-53cbbbba6f08"}],
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
Primarily, fix some examples completely missing from the docs. I'm not sure if this changed at some point, but per [1] it is necessary for examples to be placed under a "value" key in some contexts (and not others).

Also some minor improvements:

- use more realistic env name of "live" rather than "prod" in one example

- provide an example for task "links" so that the link to self can be seen

- set a specific example for updated/deadline dates on task, because the autogenerated example used the exact same datetime for both which is not realistic.

[1] https://swagger.io/docs/specification/adding-examples/