### PR TITLE
docs: minor edits to API doc text

### DIFF
--- a/exodus_gw/main.py
+++ b/exodus_gw/main.py
@@ -42,9 +42,9 @@ internal documentation for advice on how to authenticate with exodus-gw.
 Many APIs in exodus-gw use the concept of an "environment" to control the target system
 of an operation.
 
-The set of environments is configured when exodus-gw is deployed. For example, separate
-"production" and "staging" environments may be configured, making use of separate storage
-backends.
+The set of environments is configured when exodus-gw is deployed.
+A typical scenario is to deploy a "pre" environment for pre-release content and a
+"live" environment for live content.
 
 Different environments will also require the user to hold different roles. For example,
 a client might be permitted only to write to one of the configured environments, or all

--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -59,8 +59,8 @@ s3 = boto3.resource('s3',
                     verify='/path/to/bundle.pem',
                     config=Config(client_cert=('client.crt', 'client.key')))
 
-# Bucket name must match one of the section names in exodus-gw.ini without 'env.' prefix
-bucket = s3.Bucket('dev')
+# Bucket name must match one of the environment names
+bucket = s3.Bucket('live')
 
 # Basic APIs such as upload_file now work as usual
 bucket.upload_file('/tmp/hello.txt',


### PR DESCRIPTION
- use more realistic environment names which give a better idea of how they are used in practice.

- in the boto code example, don't refer to exodus-gw.ini. The target audience of the API docs are exodus-gw *users*, not exodus-gw *owners*. The users are not expected to know the details of exodus-gw's configuration files.

  The concept of "Environments" is already explained in the API docs, so the text should simply reference that.