### PR TITLE
Fix postgres deadlock on items [RHELDST-22078]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -56,6 +56,7 @@ class Publish(Base):
         # Store only publish items with link targets.
         ln_items = (
             db.query(Item)
+            .with_for_update()
             .filter(Item.publish_id == self.id)
             .filter(
                 func.coalesce(Item.link_to, "") != ""  # pylint: disable=E1102


### PR DESCRIPTION
A few deadlocks were encountered between web & worker during concurrent phase1 commits, like this:

    psycopg2.errors.DeadlockDetected: deadlock detected
    DETAIL:  Process 9747 waits for ShareLock on transaction 396668842; blocked by process 11530.
    Process 11530 waits for ShareLock on transaction 396668846; blocked by process 9747.
    HINT:  See server log for query details.
    CONTEXT:  while locking tuple (13266,14) in relation "items"

I believe the missing "FOR UPDATE" here is the cause. Without it, the following can happen:

- web, in resolve_links:
    - selects items A, B
    - updates items A, B in memory (not flushed by sqlalchemy yet)
    - starts flush/commit:
        - updates item B in DB (obtaining lock)
- worker:
    - selects items A, B FOR UPDATE
    - successfully acquires lock on A
    - starts waiting for lock on B
- web:
    - tries to update item A in DB (has to obtain lock)

At this point deadlock has occurred:
  - worker holds A, waiting for B to become unlocked
  - web holds B, waiting for A to become unlocked

If both web and worker are selecting items FOR UPDATE, and in the same order, no deadlock should be possible here.