### PR TITLE
docs: redirect from root of service to /redoc

### DIFF
--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -2,8 +2,9 @@
 
 import logging
 from datetime import datetime, timedelta
+from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Response
 from sqlalchemy.orm import Session
 
 from .. import deps, models, schemas
@@ -16,6 +17,24 @@ LOG = logging.getLogger("exodus-gw")
 openapi_tag = {"name": "service", "description": __doc__}
 
 router = APIRouter(tags=[openapi_tag["name"]])
+
+
+@router.get(
+    "/",
+    include_in_schema=False,
+)
+async def redirect(accept: Optional[str] = Header(default=None)):
+    """Redirect from service root to API docs. For browsers only."""
+
+    # We only send the redirect if it seems like the client is a browser.
+    # The point is that this is not a part of the API and we want this to
+    # be more or less hidden to your typical clients like curl, requests.
+    if accept and "text/html" in accept:
+        return Response(
+            content=None, headers={"location": "/redoc"}, status_code=302
+        )
+
+    raise HTTPException(404)
 
 
 @router.get(

--- a/tests/routers/test_common.py
+++ b/tests/routers/test_common.py
@@ -11,7 +11,11 @@ from exodus_gw.main import app
 
 
 def all_api_routes():
-    return [r for r in app.routes if isinstance(r, APIRoute)]
+    return [
+        r
+        for r in app.routes
+        if isinstance(r, APIRoute) and r.include_in_schema
+    ]
 
 
 @pytest.fixture(params=all_api_routes(), ids=lambda route: route.path)

--- a/tests/routers/test_service.py
+++ b/tests/routers/test_service.py
@@ -87,3 +87,29 @@ def test_get_task(db):
     # Last request should have succeeded and returned the correct object.
     assert resp.status_code == 200
     assert resp.json()["publish_id"] == publish_id
+
+
+def test_redirect_to_docs():
+    """Accessing / from a browser redirects to docs."""
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/",
+            headers={
+                "Accept": "text/html,application/xhtml+xml,application/xml"
+            },
+        )
+
+        # Note the TestClient follows redirects, so this is actually
+        # covering both the fact that a redirect happened and that
+        # the target URL serves up redoc stuff.
+        assert resp.status_code == 200
+        assert '<redoc spec-url="/openapi.json">' in resp.text
+
+
+def test_root_non_browser():
+    """Accessing / from non-browser gives 404."""
+
+    with TestClient(app) as client:
+        resp = client.get("/")
+        assert resp.status_code == 404


### PR DESCRIPTION
Since there is no API at "/", previously if opening up the service in a browser, one would see a 404 Not Found error in JSON format. It gives the impression that there might be something wrong with the service.

Let's make it so that accessing the root of the service will redirect to the docs to fix this and help with discoverability of the API.

This logic is limited to browsers (judged by clients requesting an HTML response) so that other clients wouldn't come to depend on it.