### PR TITLE
Fix links repeatedly resolved for large publishes [RHELDST-22081]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -104,6 +104,9 @@ class Publish(Base):
             ln_item.object_key = match.get("object_key")
             ln_item.content_type = match.get("content_type")
 
+            # The link has been resolved. Wipe it out so it's not resolved again.
+            ln_item.link_to = None
+
 
 class Item(Base):
     __tablename__ = "items"

--- a/tests/routers/test_publish.py
+++ b/tests/routers/test_publish.py
@@ -1003,6 +1003,10 @@ def test_commit_publish_linked_items(mock_commit, fake_publish, db):
     # Should've filled ln_item2's content_type with that of item2.
     assert ln_item2.content_type == "another type"
 
+    # Should've unset the link_to, since links have been resolved.
+    assert ln_item1.link_to is None
+    assert ln_item2.link_to is None
+
     # Should've created and sent task.
     assert isinstance(publish_task, Task)
 


### PR DESCRIPTION
After the introduction of phase1 commits, for one publish involving (say) 600 Pulp repos, it's expected that a phase1 commit happens 600 times. Resolution of "link_to" happens as a part of this.

Problem: the query finding items for link resolution would find all items with a non-empty "link_to", but we never *set* the field to empty after resolving links. That means that every request to the commit endpoint for that publish is resolving not only any recently added links, but also all previously added links even if they were already resolved before.

Worse, all the items selected for resolution need to be locked FOR UPDATE, while any workers processing a commit *also* need to lock the same items FOR UPDATE.

As a result, for publishes involving many repos, the commit endpoint could slow down unreasonably over time.

This commit fixes it by wiping out the link_to field once we have resolved links so that the same item does not get resolved more than once.