### PR TITLE
Add PULP_MANIFEST.asc to default entry point patterns

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -160,6 +160,7 @@ class Settings(BaseSettings):
         "repomd.xml",
         "repomd.xml.asc",
         "PULP_MANIFEST",
+        "PULP_MANIFEST.asc",
     ]
     """List of file names that should be saved for last when publishing."""
 


### PR DESCRIPTION
This file is a detached signature of PULP_MANIFEST. It needs to be treated as an entrypoint / as phase2 content, similarly to the existing repomd.xml.asc.