### PR TITLE
logging: propagate correlation ID through dramatiq

### DIFF
--- a/exodus_gw/dramatiq/broker.py
+++ b/exodus_gw/dramatiq/broker.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from exodus_gw.database import db_engine
 from exodus_gw.dramatiq.consumer import Consumer
 from exodus_gw.dramatiq.middleware import (
+    CorrelationIdMiddleware,
     DatabaseReadyMiddleware,
     LocalNotifyMiddleware,
     LogActorMiddleware,
@@ -51,6 +52,9 @@ class Broker(dramatiq.Broker):  # pylint: disable=abstract-method
         # Enable automatic prefixing of log messages with actor names/identity
         # such as "[commit <publish-id>] the log message..."
         self.add_middleware(LogActorMiddleware())
+
+        # Allow correlation ID to propagate between web and worker
+        self.add_middleware(CorrelationIdMiddleware())
 
         # Ensure all actors can get access to the current settings.
         self.add_middleware(SettingsMiddleware(self.__settings))

--- a/exodus_gw/dramatiq/middleware/__init__.py
+++ b/exodus_gw/dramatiq/middleware/__init__.py
@@ -1,3 +1,4 @@
+from .correlation_id import CorrelationIdMiddleware
 from .db_ready import DatabaseReadyMiddleware
 from .local_notify import LocalNotifyMiddleware
 from .log_actor import LogActorMiddleware
@@ -10,6 +11,7 @@ __all__ = [
     "PostgresNotifyMiddleware",
     "SchedulerMiddleware",
     "LogActorMiddleware",
+    "CorrelationIdMiddleware",
     "DatabaseReadyMiddleware",
     "SettingsMiddleware",
 ]

--- a/exodus_gw/dramatiq/middleware/correlation_id.py
+++ b/exodus_gw/dramatiq/middleware/correlation_id.py
@@ -1,0 +1,37 @@
+import functools
+
+from asgi_correlation_id import correlation_id
+from dramatiq import Middleware
+
+
+class CorrelationIdMiddleware(Middleware):
+    """Middleware passing correlation ID from web to workers."""
+
+    def before_declare_actor(self, broker, actor):
+        # On the worker side: ensure the actor accepts "correlation_id"
+        self.__wrap_with_correlation_id(actor)
+
+    def before_enqueue(self, broker, message, delay):
+        # On the web side: ensure that enqueued messages include
+        # a "correlation_id".
+        message.kwargs["correlation_id"] = correlation_id.get()
+
+    def __wrap_with_correlation_id(self, actor):
+        # Wrap actor's callable so that it accepts a "correlation_id" argument
+        # which, if provided, is automatically propagated into
+        # asgi_correlation_id.correlation_id.
+        original_fn = actor.fn
+
+        @functools.wraps(original_fn)
+        def new_fn(*args, **kwargs):
+            token = None
+            if input_id := kwargs.pop("correlation_id", None):
+                token = correlation_id.set(input_id)
+
+            try:
+                return original_fn(*args, **kwargs)
+            finally:
+                if token:
+                    correlation_id.reset(token)
+
+        actor.fn = new_fn


### PR DESCRIPTION
The asgi_correlation_id log filter is enabled even in the dramatiq worker, but so far it always logged "request_id": null since the id was not propagated in any way.

This commit adds another dramatiq middleware to automatically propagate it. This allows matching up logs from a worker's task with logs from whichever HTTP request spawned that task, which previously has sometimes not been possible. asgi_correlation_id itself already maintains an extension to do this with celery, so it seems propagating the id into background tasks is an intended usage.