### PR TITLE
autoindex in the background for improved performance [RHELDST-22148]

### DIFF
--- a/exodus_gw/worker/__init__.py
+++ b/exodus_gw/worker/__init__.py
@@ -10,6 +10,7 @@ dramatiq.set_broker(Broker())
 #
 # pylint: disable=wrong-import-position
 
+from .autoindex import autoindex_partial  # noqa
 from .deploy import deploy_config  # noqa
 from .publish import commit  # noqa
 from .scheduled import cleanup  # noqa


### PR DESCRIPTION
autoindex step formerly happened only during the commit actor. The indexing of a yum repo needs to do several requests to S3. For a typically sized repo it can take about 3-4 seconds on average. If a publish contains hundreds of repos, this means the total autoindex time might measure in the tens of minutes, which can dominate the time needed to commit.

There's no technical reason why the autoindex step has to wait until commit; it was only written that way since it was convenient to do so. It would be better if the work could be done prior to commit.

It's possible to do an autoindex on a specific repo as soon as that repo's entry points / repodata have been added to the publish, so let's start doing that: when an entry point is added, a background autoindex actor is triggered to do autoindexing work for just that entry point. This is invisible to the user.

autoindex at commit time still happens as always and will catch anything missed previously, but in typical scenarios it will hopefully find that all the indexes are already present.