### PR TITLE
Improve performance via partial link resolution [RHELDST-22147]

### DIFF
--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -43,7 +43,7 @@ class ItemBase(BaseModel):
         ...,
         description="URI, relative to CDN root, which shall be used to expose this object.",
     )
-    object_key: str = Field(
+    object_key: Optional[str] = Field(
         "",
         description=(
             "Key of blob to be exposed; should be the SHA256 checksum of a previously uploaded "
@@ -53,11 +53,13 @@ class ItemBase(BaseModel):
             "content from the point of view of a CDN consumer."
         ),
     )
-    content_type: str = Field(
+    content_type: Optional[str] = Field(
         "",
         description="Content type of the content associated with this object.",
     )
-    link_to: str = Field("", description="Path of file targeted by symlink.")
+    link_to: Optional[str] = Field(
+        "", description="Path of file targeted by symlink."
+    )
 
     @model_validator(mode="after")
     def validate_item(self) -> "ItemBase":


### PR DESCRIPTION
Links were previously resolved only at commit time. In most cases, we have all the needed info to resolve links as items are being added to a publish:

- if items being added are links to items which already exist in the DB, they can be immediately resolved before saving.

- if items being added are targets of links which already exist in the DB, those existing items in the DB can be updated as part of the current request.

This change adds the needed logic to resolve links during update for the above two cases. The motivation is that, per observations during a very large publish in RHELDST-22147, it was seen that some requests to "/commit" took as long as 60 seconds. This probably indicates that we're trying to do too much work in the context of a single HTTP request and it's better to find a way to split up the work across multiple requests.