### PR TITLE
Revise and improve actor logging

### DIFF
--- a/exodus_gw/logging.py
+++ b/exodus_gw/logging.py
@@ -60,6 +60,10 @@ class JsonFormatter(logging.Formatter):
             "message": "message",
             "event": "event",
             "success": "success",
+            "actor": "actor",
+            "publish_id": "publish_id",
+            "message_id": "message_id",
+            "duration_ms": "duration_ms",
         }
         self.datefmt = datefmt
 
@@ -81,7 +85,12 @@ class JsonFormatter(logging.Formatter):
         return s
 
     def formatMessage(self, record):
-        return {k: record.__dict__.get(v) for k, v in self.fmt.items()}
+        absent = object()
+        return {
+            k: record.__dict__.get(v)
+            for k, v in self.fmt.items()
+            if record.__dict__.get(v, absent) is not absent
+        }
 
     def format(self, record):
         record.message = record.getMessage()


### PR DESCRIPTION
This commit revamps the LogActor dramatiq middleware to resolve some issues observed in the logs.

The main changes are:

- Instead of prefixing log messages with e.g. "[commit abc123]", put that info into proper fields rendered into our JSON logs, e.g. {"actor": "commit", "publish_id": "abc123", ...}

- Include the message ID (which we reuse as task ID). In the case of phase1 commits which can happen multiple times for a single publish, without logging the message ID we can't match up which logs came from which task.

- Produce generic start/stop/failed messages for every actor, which also include the actor's duration. Without this there was no clear way to tell when actors started and ended, since most of our actors themselves aren't designed to log that internally.

- In the JSON log formatter, just skip any fields which are missing from the log record rather than logging them as null. This is done because the set of fields differ between web & worker, so either we need to use two separate log formats or we just ignore absent fields.