### PR TITLE
Fix dramatiq test issue leading to stack overflow

### DIFF
--- a/exodus_gw/dramatiq/middleware/db_ready.py
+++ b/exodus_gw/dramatiq/middleware/db_ready.py
@@ -1,6 +1,8 @@
+from collections.abc import Callable
+
 import backoff
 from dramatiq import Middleware
-from sqlalchemy import inspect
+from sqlalchemy import Engine, inspect
 
 
 @backoff.on_predicate(
@@ -15,8 +17,8 @@ def db_table_check(engine, table):
 class DatabaseReadyMiddleware(Middleware):
     """Middleware for checking if DB is ready."""
 
-    def __init__(self, db_engine):
+    def __init__(self, db_engine: Callable[[], Engine]):
         self.__db_engine = db_engine
 
     def after_process_boot(self, broker):
-        db_table_check(self.__db_engine, "dramatiq_consumers")
+        db_table_check(self.__db_engine(), "dramatiq_consumers")

--- a/tests/dramatiq/test_pg_notify.py
+++ b/tests/dramatiq/test_pg_notify.py
@@ -40,9 +40,10 @@ def test_listen_thread(caplog):
     logging.getLogger("exodus-gw").setLevel(logging.INFO)
 
     db_engine = mock.MagicMock()
+    db_engine.url = "postgresql://whatever"
     select = FakeSelect()
     broker = FakeBroker()
-    mw = PostgresNotifyMiddleware(db_engine, 0.1)
+    mw = PostgresNotifyMiddleware(lambda: db_engine, 0.1)
     broker.add_middleware(mw)
 
     with mock.patch("select.select", new=select):
@@ -88,9 +89,10 @@ def test_notifies():
     """Middleware executes postgres NOTIFY statements when relevant events occur."""
 
     db_engine = mock.MagicMock()
+    db_engine.url = "postgresql://whatever"
     db_conn = db_engine.connect().__enter__()
     broker = FakeBroker()
-    mw = PostgresNotifyMiddleware(db_engine)
+    mw = PostgresNotifyMiddleware(lambda: db_engine)
     broker.add_middleware(mw)
 
     # These should all result in notifies occurring


### PR DESCRIPTION
Dramatiq actors are declared at import time, before our test fixtures have had a chance to set up the test DB. In order to ensure dramatiq points at the test DB, the prior solution was an autouse fixture which would create a new temporary broker pointing at the test DB and move all existing actors over to that.

There was a major issue with this which went unnoticed: all the middlewares were recreated each time. Since some of the middlewares work by wrapping the functions on the actors, this meant every test would add a new level of wrapped functions on top of those already set up by prior tests. Once the total number of tests exceeds some threshold, the number of chained functions would be high enough to cause a stack overflow.

This commit changes the approach used to point the broker at our test DB. Rather than creating a new Broker (and new middlewares) per test, we keep the same one throughout and we add a method to it which allows resetting the DB engine and settings on the fly.