### PR TITLE
Use ordered queries to reduce deadlocks [RHELDST-22078]

### DIFF
--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -74,6 +74,7 @@ class Publish(Base):
                     func.coalesce(Item.link_to, "")  # pylint: disable=E1102
                     != ""
                 )
+                .order_by(Item.web_uri)
                 .all()
             )
         else:

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -271,6 +271,7 @@ def update_publish_items(
                 [i.web_uri for i in items if not i.link_to]
             )
         )
+        .order_by(models.Item.web_uri)
         .all()
     )
 
@@ -290,6 +291,7 @@ def update_publish_items(
         }
         for item in items
     ]
+    items_data.sort(key=lambda item: item["web_uri"])
 
     LOG.debug(
         "Adding %s items into '%s'",

--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -234,8 +234,10 @@ class CommitBase:
         # Returns base of the SELECT query to find all items for commit.
         #
         # Can be overridden in subclasses.
-        return select(Item).where(
-            Item.publish_id == self.publish.id, Item.dirty == True
+        return (
+            select(Item)
+            .where(Item.publish_id == self.publish.id, Item.dirty == True)
+            .order_by(Item.web_uri)
         )
 
     @property


### PR DESCRIPTION
There are still DB deadlocks occurring from time to time. These all seem to be related to multiple rhsm-pulp repos updating records for the same files concurrently (e.g. multiple repos having the same RPMs will all need to update the same paths under /origin/ around the same time).

While the relevant code is all prepared to retry on deadlock anyway and so this should not be noticeable beyond a delay, it would be nice to fix this.

This commit tries to fix it by always applying a consistent order for all queries obtaining row locks on items. The change is speculative as I can't reproduce the deadlocks on demand, but it's consistent with the advice given in postgres docs[1]:

> The best defense against deadlocks is generally to avoid them by being
> certain that all applications using a database acquire locks on
> multiple objects in a consistent order

[1] https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS