### PR TITLE
Ensure kickstart entrypoints are listed in default settings

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -161,6 +161,8 @@ class Settings(BaseSettings):
         "repomd.xml.asc",
         "PULP_MANIFEST",
         "PULP_MANIFEST.asc",
+        "treeinfo",
+        "extra_files.json",
     ]
     """List of file names that should be saved for last when publishing."""
 


### PR DESCRIPTION
Without this, atomic behavior for kickstart repo publishes will not be achieved.