### PR TITLE
Fix missing files from kickstart indexes [RHELDST-22387]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -170,6 +170,11 @@ class Settings(BaseSettings):
     Can be set to an empty string to disable generation of indexes.
     """
 
+    autoindex_partial_excludes: List[str] = ["/kickstart/"]
+    """Background processing of autoindexes will be disabled for paths matching
+    any of these values.
+    """
+
     config_cache_ttl: int = 2
     """Time (in minutes) config is expected to live in components that consume it.
 


### PR DESCRIPTION
RHELDST-22148 introduced the concept of a partial autoindex, which is triggered as soon as entry points are added onto a publish without waiting until commit.

This introduced a problem for kickstart repos. The problem is that a kickstart repo is simultaneously a valid yum repo, containing both yum and kickstart entrypoints. There is no guarantee in which order the client will add these onto a publish.

If the client added yum repodata first, partial autoindex could be triggered and successfully parse the repo as a yum repo (only). If the client then later added kickstart repodata, the autoindex would not be regenerated to include kickstart files, because the index is treated as immutable and assumed valid if it already exists on the publish.

This commit fixes the problem by effectively disabling partial autoindex for kickstart repos, allowing them to instead generate indexes at commit time as it worked originally.

This can be considered more of a workaround than a proper fix. A better fix might be done later to make autoindex_partial work correctly for kickstart repos rather than disabling it.