### PR TITLE
Add missing URL encoding during CDN redirect [RHELDST-22493]

### DIFF
--- a/exodus_gw/routers/cdn.py
+++ b/exodus_gw/routers/cdn.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from botocore.utils import datetime2timestamp
 from cryptography.hazmat.backends import default_backend
@@ -200,6 +200,7 @@ def cdn_redirect(
         or call_context.user.internalUsername
         or "<unknown user>"
     )
+    url = quote(url)
     signed_url = sign_url(url, settings, env, username)
     return Response(
         content=None, headers={"location": signed_url}, status_code=302

--- a/tests/routers/test_cdn.py
+++ b/tests/routers/test_cdn.py
@@ -118,6 +118,30 @@ def test_cdn_redirect_(monkeypatch, dummy_private_key, caplog):
     }
 
 
+@freeze_time("2022-02-16")
+def test_cdn_redirect_encoding(monkeypatch, dummy_private_key, caplog):
+    """Paths involving special characters get encoded during redirect."""
+    caplog.set_level(logging.DEBUG, "exodus-gw")
+    monkeypatch.setenv("EXODUS_GW_CDN_PRIVATE_KEY_TEST", dummy_private_key)
+
+    with TestClient(app) as client:
+        r = client.get(
+            "/test/cdn/some/url-with-^-character", follow_redirects=False
+        )
+
+    expected_cookies = "WyJDbG91ZEZyb250LUtleS1QYWlyLUlkPVhYWFhYWFhYWFhYWFhYOyBTZWN1cmU7IEh0dHBPbmx5OyBTYW1lU2l0ZT1sYXg7IERvbWFpbj1sb2NhbGhvc3Q6ODA0OTsgUGF0aD0vY29udGVudC87IE1heC1BZ2U9NDMyMDAiLCAiQ2xvdWRGcm9udC1Qb2xpY3k9ZXlKVGRHRjBaVzFsYm5RaU9sdDdJbEpsYzI5MWNtTmxJam9pYUhSMGNEb3ZMMnh2WTJGc2FHOXpkRG80TURRNUwyTnZiblJsYm5RdktpSXNJa052Ym1ScGRHbHZiaUk2ZXlKRVlYUmxUR1Z6YzFSb1lXNGlPbnNpUVZkVE9rVndiMk5vVkdsdFpTSTZNVFkwTlRBeE1qZ3dNSDE5ZlYxOTsgU2VjdXJlOyBIdHRwT25seTsgU2FtZVNpdGU9bGF4OyBEb21haW49bG9jYWxob3N0OjgwNDk7IFBhdGg9L2NvbnRlbnQvOyBNYXgtQWdlPTQzMjAwIiwgIkNsb3VkRnJvbnQtU2lnbmF0dXJlPU5XUGZnb3REdTJEa0g0ZjRkNjhlVWtMTk5hVmZKR2hpenp4UlJleGI1NVh0Y0o3Qzk2cEF4ekd3cX56UWJoNndyMHhhMlh4Zll3UjV5dEs1MmJXQ3JCTGJWVHI5WWd0M2Z3Z3FDZTl1cWl1dnJoU3V-WDd3Z0VPbkVvT053Sng2WGw1VkFERU4yYXBVblBMQ1hJVEQybXYtNnJDaFhmemdaMXg0UER5OGo4MF87IFNlY3VyZTsgSHR0cE9ubHk7IFNhbWVTaXRlPWxheDsgRG9tYWluPWxvY2FsaG9zdDo4MDQ5OyBQYXRoPS9jb250ZW50LzsgTWF4LUFnZT00MzIwMCIsICJDbG91ZEZyb250LUtleS1QYWlyLUlkPVhYWFhYWFhYWFhYWFhYOyBTZWN1cmU7IEh0dHBPbmx5OyBTYW1lU2l0ZT1sYXg7IERvbWFpbj1sb2NhbGhvc3Q6ODA0OTsgUGF0aD0vb3JpZ2luLzsgTWF4LUFnZT00MzIwMCIsICJDbG91ZEZyb250LVBvbGljeT1leUpUZEdGMFpXMWxiblFpT2x0N0lsSmxjMjkxY21ObElqb2lhSFIwY0RvdkwyeHZZMkZzYUc5emREbzRNRFE1TDI5eWFXZHBiaThxSWl3aVEyOXVaR2wwYVc5dUlqcDdJa1JoZEdWTVpYTnpWR2hoYmlJNmV5SkJWMU02UlhCdlkyaFVhVzFsSWpveE5qUTFNREV5T0RBd2ZYMTlYWDBfOyBTZWN1cmU7IEh0dHBPbmx5OyBTYW1lU2l0ZT1sYXg7IERvbWFpbj1sb2NhbGhvc3Q6ODA0OTsgUGF0aD0vb3JpZ2luLzsgTWF4LUFnZT00MzIwMCIsICJDbG91ZEZyb250LVNpZ25hdHVyZT1NaW8za2w5enpCZXE2WUtjREY0aFdHNGlIRFhnLWRwSnV-VmtkWklYZVhPM0lsZzE3OTZUWlFBZGpLLWN6Tm5aQzBUNWVmVzNEbGlKQWVMSmhYd351MVZoTkpSQ0lvUTZmTGJDVnV4MVRHMzAtUC1FVzR-a1JmU2dlWjV2RVcydTBNWXpsQ0pNZndZSUoxQ1ZlejlMdTJ3a2NIMjFQTkNjc2liS25tTmZjbk1fOyBTZWN1cmU7IEh0dHBPbmx5OyBTYW1lU2l0ZT1sYXg7IERvbWFpbj1sb2NhbGhvc3Q6ODA0OTsgUGF0aD0vb3JpZ2luLzsgTWF4LUFnZT00MzIwMCJd"
+    expected_url = (
+        "http://localhost:8049/_/cookie/some/"
+        f"url-with-%5E-character?CloudFront-Cookies={expected_cookies}"
+        "&Expires=1644971400"
+        "&Signature=AKw-NwPUavLgMsk2j5fikOvCOIWXqnaFtaabzMNeXyY5VMkSd1Rt226m6VaVEj~dQpf71GUAe1dKlvPXqCUYXXHlcFPAktES7IXvg7O88c-MDMak2q2lUy0~-l6Q2kTJWJeWvGtHTBnRXEM215U5SqODnZtVW98F4mEgJGg6vEU_"
+        "&Key-Pair-Id=XXXXXXXXXXXXXX"
+    )
+
+    assert r.status_code == 302
+    assert r.headers["location"] == expected_url
+
+
 def test_sign_url_without_private_key():
     env = get_environment("test")
 


### PR DESCRIPTION
The URLs used here for redirect ought to be percent-encoded.

Although neither CloudFront nor exodus-lambda care about this, if not encoded, some clients will break. python-requests is an example of a client which breaks (while curl is OK).

What happens with python-requests is like this:

1. python-requests caller requests the CDN redirect API with a path having a reserved character, e.g. /some^path
2. python-requests automatically encodes to /some%5Epath
3. starlette/gunicorn/whatever automatically decodes to /some^path, so that's what the exodus-gw code sees
4. exodus-gw responds with a redirect, with Location: <cdn_endpoint>/some^path
5. python-requests automatically encodes *that* to <cdn_endpoint>/some%5Epath when issuing the follow-up request
6. since the final URL for the request used "%5E", but the URL used internally by exodus-gw when generating CloudFront signatures used "^", the request will fail CloudFront signature verification.

Quoting/escaping before signing should fix the issue, as the path returned at step (4) would already use %5E, would be consistent with the signature, and wouldn't be rewritten by python-requests or other clients.