### PR TITLE
Use python3.11 consistently in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py311, static, docs
 
 [testenv]
+basepython = python3.11
 deps=
 	-r requirements.txt
 	-r test-requirements.txt
@@ -10,7 +11,6 @@ allowlist_externals=sh
 
 [testenv:pip-compile]
 deps = pip-tools
-basepython = python3.11
 skip_install = true
 skipsdist = true
 commands =
@@ -58,14 +58,12 @@ commands=
     python scripts/alembic-autogen {posargs}
 
 [testenv:dev-worker]
-basepython = python3.11
 use_develop=true
 passenv=EXODUS_GW*
 commands=
     dramatiq --watch exodus_gw --watch-use-polling exodus_gw.worker -p 1 {posargs}
 
 [testenv:dev-server]
-basepython = python3.11
 use_develop=true
 passenv=EXODUS_GW*
 commands=


### PR DESCRIPTION
python 3.11 is intended to be the primary python version used for testing and deployment of exodus-gw. Since we use that version to compile the dependencies, we should be using it in *every* tox env, as the deps may not be installable for other python versions.