### PR TITLE
Modernize type hints

### DIFF
--- a/exodus_gw/auth.py
+++ b/exodus_gw/auth.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-from typing import List, Optional, Set
 
 from fastapi import Depends, HTTPException, Request
 from pydantic import BaseModel
@@ -14,17 +13,17 @@ LOG = logging.getLogger("exodus-gw")
 class ClientContext(BaseModel):
     """Call context data relating to service accounts / machine users."""
 
-    roles: List[str] = []
+    roles: list[str] = []
     authenticated: bool = False
-    serviceAccountId: Optional[str] = None
+    serviceAccountId: str | None = None
 
 
 class UserContext(BaseModel):
     """Call context data relating to human users."""
 
-    roles: List[str] = []
+    roles: list[str] = []
     authenticated: bool = False
-    internalUsername: Optional[str] = None
+    internalUsername: str | None = None
 
 
 class CallContext(BaseModel):
@@ -79,7 +78,7 @@ async def caller_name(context: CallContext = Depends(call_context)) -> str:
 
 async def caller_roles(
     context: CallContext = Depends(call_context),
-) -> Set[str]:
+) -> set[str]:
     """Returns all roles held by the caller of the current request.
 
     This will be an empty set for unauthenticated requests.
@@ -103,8 +102,8 @@ def needs_role(rolename):
 
     async def check_roles(
         request: Request,
-        env: Optional[str] = None,
-        roles: Set[str] = Depends(caller_roles),
+        env: str | None = None,
+        roles: set[str] = Depends(caller_roles),
         caller_name: str = Depends(caller_name),
     ):
         role = env + "-" + rolename if env else rolename
@@ -134,7 +133,7 @@ def needs_role(rolename):
 
 async def log_login(
     request: Request,
-    roles: Set[str] = Depends(caller_roles),
+    roles: set[str] = Depends(caller_roles),
     caller_name: str = Depends(caller_name),
 ):
     if caller_name != "<anonymous user>":

--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 from itertools import islice
 from threading import Lock
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import backoff
 from botocore.exceptions import EndpointConnectionError
@@ -22,8 +22,8 @@ class DynamoDB:
         env: str,
         settings: Settings,
         from_date: str,
-        env_obj: Optional[Environment] = None,
-        deadline: Optional[datetime] = None,
+        env_obj: Environment | None = None,
+        deadline: datetime | None = None,
     ):
         self.env = env
         self.settings = settings
@@ -45,12 +45,12 @@ class DynamoDB:
                     self._definitions = self.query_definitions()
         return self._definitions
 
-    def query_definitions(self) -> Dict[str, Any]:
+    def query_definitions(self) -> dict[str, Any]:
         """Query the definitions in the config_table. If definitions are found, return them. Otherwise,
         return an empty dictionary."""
 
         # Return an empty dict if a query result is not found
-        out: Dict[str, Any] = {}
+        out: dict[str, Any] = {}
 
         LOG.info(
             "Loading exodus-config as at %s.",
@@ -75,12 +75,12 @@ class DynamoDB:
 
     def create_request(
         self,
-        items: List[models.Item],
+        items: list[models.Item],
         delete: bool = False,
     ):
         """Create the dictionary structure expected by batch_write_item."""
         table_name = self.env_obj.table
-        request: Dict[str, List[Any]] = {table_name: []}
+        request: dict[str, list[Any]] = {table_name: []}
 
         uri_aliases = []
         for k, v in self.definitions.items():
@@ -140,7 +140,7 @@ class DynamoDB:
         }
         return request
 
-    def batch_write(self, request: Dict[str, Any]):
+    def batch_write(self, request: dict[str, Any]):
         """Wrapper for batch_write_item with retries and item count validation.
 
         Item limit of 25 is, at this time, imposed by AWS's boto3 library.
@@ -196,7 +196,7 @@ class DynamoDB:
 
         return _batch_write(request)
 
-    def get_batches(self, items: List[models.Item]):
+    def get_batches(self, items: list[models.Item]):
         """Divide the publish items into batches of size 'write_batch_size'."""
         it = iter(items)
         batches = list(
@@ -204,7 +204,7 @@ class DynamoDB:
         )
         return batches
 
-    def write_batch(self, items: List[models.Item], delete: bool = False):
+    def write_batch(self, items: list[models.Item], delete: bool = False):
         """Submit a batch of given items for writing via batch_write."""
 
         request = self.create_request(list(items), delete)

--- a/exodus_gw/aws/log.py
+++ b/exodus_gw/aws/log.py
@@ -1,7 +1,7 @@
 """AWS logging utilities."""
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any
 
 import aioboto3
 import boto3.session
@@ -27,9 +27,9 @@ def request_logger(request: AWSPreparedRequest, **_kwargs):
 
 
 def response_logger(
-    response: Optional[tuple[AWSResponse, Any]],
+    response: tuple[AWSResponse, Any] | None,
     request_dict: dict[str, Any],
-    caught_exception: Optional[Exception],
+    caught_exception: Exception | None,
     **_kwargs
 ):
     # Callback for logging responses from AWS.
@@ -55,7 +55,7 @@ def response_logger(
     )
 
 
-def add_loggers(session: Union[boto3.session.Session, aioboto3.Session]):
+def add_loggers(session: boto3.session.Session | aioboto3.Session):
     """Add some custom loggers onto a boto session."""
 
     # Log just before we send requests.

--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -1,7 +1,7 @@
 import io
 import logging
 import re
-from typing import AnyStr, Dict
+from typing import AnyStr
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
 from defusedxml.ElementTree import fromstring
@@ -27,7 +27,7 @@ def extract_request_metadata(request: Request, settings: Settings):
     return metadata
 
 
-def validate_metadata(metadata: Dict[str, str], settings: Settings):
+def validate_metadata(metadata: dict[str, str], settings: Settings):
     valid_meta_fields = settings.upload_meta_fields
     for k, v in metadata.items():
         if k not in valid_meta_fields.keys():

--- a/exodus_gw/dramatiq/middleware/scheduler.py
+++ b/exodus_gw/dramatiq/middleware/scheduler.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 from collections.abc import Callable
 from datetime import datetime
-from typing import Optional
 
 import pycron
 from dramatiq import Middleware
@@ -78,7 +77,7 @@ class SchedulerMiddleware(Middleware):
         actor.options["unscheduled_fn"] = unscheduled_fn
 
         @functools.wraps(unscheduled_fn)
-        def new_fn(last_run: Optional[float] = None):
+        def new_fn(last_run: float | None = None):
             cron_rule = getattr(settings, settings_key)
             now = datetime.utcnow()
 

--- a/exodus_gw/migrations/test.py
+++ b/exodus_gw/migrations/test.py
@@ -2,10 +2,10 @@
 
 import functools
 import os
-import typing
+from collections.abc import Callable
 
 
-def tested_by(data_fn: typing.Callable[[], None]):
+def tested_by(data_fn: Callable[[], None]):
     """A decorator declaring a function which provides test data for
     an upgrade or downgrade operation.
 
@@ -29,7 +29,7 @@ def tested_by(data_fn: typing.Callable[[], None]):
     that migration can complete without crashing.
     """
 
-    def decorator(fn: typing.Callable[[], None]):
+    def decorator(fn: Callable[[], None]):
         @functools.wraps(fn)
         def fn_with_data():
             # Call the data function before the real migration function,

--- a/exodus_gw/models/dramatiq.py
+++ b/exodus_gw/models/dramatiq.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, Optional
+from typing import Any
 
 from sqlalchemy import DateTime, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -25,7 +25,7 @@ class DramatiqMessage(Base):
     # Null means message is not yet assigned.
     # Not a foreign key since consumers can disappear while leaving
     # their messages behind.
-    consumer_id: Mapped[Optional[str]] = mapped_column(String)
+    consumer_id: Mapped[str | None] = mapped_column(String)
 
     consumer = relationship(
         "DramatiqConsumer",
@@ -40,7 +40,7 @@ class DramatiqMessage(Base):
     actor: Mapped[str] = mapped_column(String)
 
     # Full message body.
-    body: Mapped[Dict[str, Any]] = mapped_column(JSONB)
+    body: Mapped[dict[str, Any]] = mapped_column(JSONB)
 
 
 class DramatiqConsumer(Base):

--- a/exodus_gw/models/service.py
+++ b/exodus_gw/models/service.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 
 from sqlalchemy import DateTime, ForeignKey, String, event
 from sqlalchemy.orm import Mapped, mapped_column
@@ -24,8 +23,8 @@ class Task(Base):
     id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True)
     type: Mapped[str]
     state: Mapped[str] = mapped_column(String)
-    updated: Mapped[Optional[datetime]] = mapped_column(DateTime())
-    deadline: Mapped[Optional[datetime]] = mapped_column(DateTime())
+    updated: Mapped[datetime | None] = mapped_column(DateTime())
+    deadline: Mapped[datetime | None] = mapped_column(DateTime())
 
 
 class CommitTask(Task):

--- a/exodus_gw/routers/deploy.py
+++ b/exodus_gw/routers/deploy.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any
 
 import jsonschema
 from fastapi import APIRouter, Body, HTTPException
@@ -113,7 +113,7 @@ CONFIG_SCHEMA = {
     },
 )
 def deploy_config(
-    config: Dict[str, Any] = Body(
+    config: dict[str, Any] = Body(
         ...,
         examples=[
             {

--- a/exodus_gw/routers/publish.py
+++ b/exodus_gw/routers/publish.py
@@ -113,7 +113,6 @@ indefinitely.
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union
 from uuid import uuid4
 
 from fastapi import APIRouter, Body, HTTPException, Query
@@ -180,7 +179,7 @@ def publish(
     dependencies=[auth.needs_role("publisher")],
 )
 def update_publish_items(
-    items: List[schemas.ItemBase] = Body(
+    items: list[schemas.ItemBase] = Body(
         ...,
         examples=[
             [
@@ -209,7 +208,7 @@ def update_publish_items(
     env: Environment = deps.env,
     db: Session = deps.db,
     settings: Settings = deps.settings,
-) -> Dict[None, None]:
+) -> dict[None, None]:
     """Add publish items to an existing publish object.
 
     **Required roles**: `{env}-publisher`
@@ -256,7 +255,7 @@ def update_publish_items(
     # (2) any item we're about to save whose 'link_to' matches one of the 'web_uri'
     #     of a non-link item already in the DB.
     #
-    resolvable: list[Union[schemas.ItemBase, models.Item]] = []
+    resolvable: list[schemas.ItemBase | models.Item] = []
     resolvable.extend(items)
     resolvable.extend(
         db.query(models.Item)
@@ -383,10 +382,10 @@ def commit_publish(
     env: Environment = deps.env,
     db: Session = deps.db,
     settings: Settings = deps.settings,
-    deadline: Union[str, None] = Query(
+    deadline: str | None = Query(
         default=None, examples=["2022-07-25T15:47:47Z"]
     ),
-    commit_mode: Optional[models.CommitModes] = Query(
+    commit_mode: models.CommitModes | None = Query(
         default=None,
         title="commit mode",
         description="See: [Two-phase commit](#section/Two-phase-commit)",

--- a/exodus_gw/routers/service.py
+++ b/exodus_gw/routers/service.py
@@ -2,7 +2,6 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import Optional
 
 from fastapi import APIRouter, Header, HTTPException, Response
 from sqlalchemy.orm import Session
@@ -23,7 +22,7 @@ router = APIRouter(tags=[openapi_tag["name"]])
     "/",
     include_in_schema=False,
 )
-async def redirect(accept: Optional[str] = Header(default=None)):
+async def redirect(accept: str | None = Header(default=None)):
     """Redirect from service root to API docs. For browsers only."""
 
     # We only send the redirect if it seems like the client is a browser.

--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -70,7 +70,6 @@ bucket.upload_file('/tmp/hello.txt',
 
 import logging
 import textwrap
-from typing import Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
 
@@ -104,7 +103,7 @@ async def multipart_upload(
     env: Environment = deps.env,
     s3: S3ClientWrapper = deps.s3_client,
     key: str = Path(..., description="S3 object key"),
-    uploadId: Optional[str] = Query(
+    uploadId: str | None = Query(
         None,
         description=textwrap.dedent(
             """
@@ -116,7 +115,7 @@ async def multipart_upload(
             Must not be passed together with ``uploads``."""
         ),
     ),
-    uploads: Optional[str] = Query(
+    uploads: str | None = Query(
         None,
         description=textwrap.dedent(
             """
@@ -170,10 +169,10 @@ async def upload(
     env: Environment = deps.env,
     s3: S3ClientWrapper = deps.s3_client,
     key: str = Path(..., description="S3 object key"),
-    uploadId: Optional[str] = Query(
+    uploadId: str | None = Query(
         None, description="ID of an existing multi-part upload."
     ),
-    partNumber: Optional[int] = Query(
+    partNumber: int | None = Query(
         None, description="Part number, where multi-part upload is used."
     ),
     settings: Settings = deps.settings,
@@ -211,7 +210,7 @@ async def object_put(
     env: Environment,
     key: str,
     request: Request,
-    metadata: Dict[str, str],
+    metadata: dict[str, str],
 ):
     # Single-part upload handler: entire object is written via one PUT.
     reader = RequestReader.get_reader(request)
@@ -269,7 +268,7 @@ async def create_multipart_upload(
     s3: S3ClientWrapper,
     env: Environment,
     key: str,
-    metadata: Dict[str, str],
+    metadata: dict[str, str],
 ):
     validate_object_key(key)
 

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -2,7 +2,6 @@ import re
 from datetime import datetime
 from enum import Enum
 from os.path import join, normpath
-from typing import Dict, List, Optional
 from uuid import UUID
 
 from fastapi import Path
@@ -43,7 +42,7 @@ class ItemBase(BaseModel):
         ...,
         description="URI, relative to CDN root, which shall be used to expose this object.",
     )
-    object_key: Optional[str] = Field(
+    object_key: str | None = Field(
         "",
         description=(
             "Key of blob to be exposed; should be the SHA256 checksum of a previously uploaded "
@@ -53,11 +52,11 @@ class ItemBase(BaseModel):
             "content from the point of view of a CDN consumer."
         ),
     )
-    content_type: Optional[str] = Field(
+    content_type: str | None = Field(
         "",
         description="Content type of the content associated with this object.",
     )
-    link_to: Optional[str] = Field(
+    link_to: str | None = Field(
         "", description="Path of file targeted by symlink."
     )
 
@@ -129,7 +128,7 @@ class PublishStates(str, Enum):
     failed = "FAILED"
 
     @classmethod
-    def terminal(cls) -> List["PublishStates"]:
+    def terminal(cls) -> list["PublishStates"]:
         return [cls.committed, cls.failed]
 
 
@@ -144,14 +143,14 @@ class Publish(PublishBase):
     state: PublishStates = Field(
         ..., description="Current state of this publish."
     )
-    updated: Optional[datetime] = Field(
+    updated: datetime | None = Field(
         None,
         description="DateTime of last update to this publish. None if never updated.",
     )
-    links: Dict[str, str] = Field(
+    links: dict[str, str] = Field(
         {}, description="""URL links related to this publish."""
     )
-    items: List[Item] = Field(
+    items: list[Item] = Field(
         [],
         description="""All items (pieces of content) included in this publish.""",
     )
@@ -170,27 +169,27 @@ class TaskStates(str, Enum):
     failed = "FAILED"
 
     @classmethod
-    def terminal(cls) -> List["TaskStates"]:
+    def terminal(cls) -> list["TaskStates"]:
         return [cls.failed, cls.complete]
 
 
 class Task(BaseModel):
     id: UUID = Field(..., description="Unique ID of task object.")
-    publish_id: Optional[UUID] = Field(
+    publish_id: UUID | None = Field(
         None, description="Unique ID of publish object handled by this task."
     )
     state: TaskStates = Field(..., description="Current state of this task.")
-    updated: Optional[datetime] = Field(
+    updated: datetime | None = Field(
         None,
         description="DateTime of last update to this task. None if never updated.",
         examples=["2019-08-24T14:15:22Z"],
     )
-    deadline: Optional[datetime] = Field(
+    deadline: datetime | None = Field(
         None,
         description="DateTime at which this task should be abandoned.",
         examples=["2019-08-24T18:15:22Z"],
     )
-    links: Dict[str, str] = Field(
+    links: dict[str, str] = Field(
         {},
         description="""URL links related to this task.""",
         examples=[{"self": "/task/497f6eca-6276-4993-bfeb-53cbbbba6f08"}],

--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -1,7 +1,7 @@
 import configparser
 import os
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from fastapi import HTTPException
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -49,22 +49,22 @@ class Settings(BaseSettings):
     and authorization).
     """
 
-    upload_meta_fields: Dict[str, str] = {}
+    upload_meta_fields: dict[str, str] = {}
     """Permitted metadata field names for s3 uploads and their regex
     for validation. E.g., "exodus-migration-md5": "^[0-9a-f]{32}$"
     """
 
-    log_config: Dict[str, Any] = {
+    log_config: dict[str, Any] = {
         "version": 1,
         "incremental": True,
         "disable_existing_loggers": False,
     }
     """Logging configuration in dictConfig schema."""
 
-    ini_path: Optional[str] = None
+    ini_path: str | None = None
     """Path to an exodus-gw.ini config file with additional settings."""
 
-    environments: List[Environment] = []
+    environments: list[Environment] = []
     # List of environment objects derived from exodus-gw.ini.
 
     db_service_user: str = "exodus-gw"
@@ -76,7 +76,7 @@ class Settings(BaseSettings):
     db_service_port: str = "5432"
     """db service port"""
 
-    db_url: Optional[str] = None
+    db_url: str | None = None
     """Connection string for database. If set, overrides the ``db_service_*`` settings."""
 
     db_reset: bool = False
@@ -156,7 +156,7 @@ class Settings(BaseSettings):
     off retries. Defaults to five (5) minutes.
     """
 
-    entry_point_files: List[str] = [
+    entry_point_files: list[str] = [
         "repomd.xml",
         "repomd.xml.asc",
         "PULP_MANIFEST",
@@ -172,7 +172,7 @@ class Settings(BaseSettings):
     Can be set to an empty string to disable generation of indexes.
     """
 
-    autoindex_partial_excludes: List[str] = ["/kickstart/"]
+    autoindex_partial_excludes: list[str] = ["/kickstart/"]
     """Background processing of autoindexes will be disabled for paths matching
     any of these values.
     """
@@ -295,7 +295,7 @@ def load_settings() -> Settings:
     return settings
 
 
-def get_environment(env: str, settings: Optional[Settings] = None):
+def get_environment(env: str, settings: Settings | None = None):
     """Return the corresponding environment object for the given environment
     name.
     """

--- a/exodus_gw/worker/autoindex.py
+++ b/exodus_gw/worker/autoindex.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from time import monotonic
-from typing import AsyncGenerator, BinaryIO, Generator, Optional
+from typing import AsyncGenerator, BinaryIO, Generator
 
 import dramatiq
 from botocore.exceptions import ClientError
@@ -46,7 +46,7 @@ class PublishContentFetcher:
         self.s3_client = s3_client
         self.environment = environment
 
-    async def __call__(self, uri: str) -> Optional[BinaryIO]:
+    async def __call__(self, uri: str) -> BinaryIO | None:
         LOG.debug("Requested to fetch: %s", uri, extra={"event": "publish"})
 
         matched = (
@@ -59,7 +59,7 @@ class PublishContentFetcher:
             return None
 
         item: Item = matched[0]
-        key: Optional[str] = item.object_key
+        key: str | None = item.object_key
         LOG.debug(
             "%s can be fetched from %s", uri, key, extra={"event": "publish"}
         )
@@ -106,7 +106,7 @@ class AutoindexEnricher:
         publish: Publish,
         env_name: str,
         settings: Settings,
-        web_uri_filter: Optional[list[str]] = None,
+        web_uri_filter: list[str] | None = None,
     ):
         self.publish = publish
         self.env_name = env_name

--- a/exodus_gw/worker/deploy.py
+++ b/exodus_gw/worker/deploy.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 import dramatiq
 from dramatiq.middleware import CurrentMessage
@@ -47,7 +47,7 @@ def complete_deploy_config_task(task_id: str):
     time_limit=Settings().actor_time_limit,
     max_backoff=Settings().actor_max_backoff,
 )
-def deploy_config(config: Dict[str, Any], env: str, from_date: str):
+def deploy_config(config: dict[str, Any], env: str, from_date: str):
     settings = Settings()
     db = Session(bind=db_engine(settings))
     ddb = DynamoDB(env, settings, from_date)

--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from os.path import basename
 from queue import Empty, Full, Queue
 from threading import Thread
-from typing import Any, List, Optional
+from typing import Any
 
 import dramatiq
 from dramatiq.middleware import CurrentMessage
@@ -42,8 +42,8 @@ class _BatchWriter:
         self.delete = delete
         self.queue: Any = Queue(self.settings.write_queue_size)
         self.sentinel = object()
-        self.threads: List[Thread] = []
-        self.errors: List[Exception] = []
+        self.threads: list[Thread] = []
+        self.errors: list[Exception] = []
         self.progress_logger = ProgressLogger(
             message=message,
             items_total=item_count,
@@ -107,10 +107,10 @@ class _BatchWriter:
         )
         self.errors.append(err)
 
-    def queue_batches(self, items: List[Item]) -> List[str]:
+    def queue_batches(self, items: list[Item]) -> list[str]:
         batches = self.dynamodb.get_batches(items)
         timeout = self.settings.write_queue_timeout
-        queued_item_ids: List[str] = []
+        queued_item_ids: list[str] = []
 
         for batch in batches:
             # Don't attempt to put more items on the queue if error(s)
@@ -160,7 +160,7 @@ class CommitBase:
     ):
         self.env = env
         self.from_date = from_date
-        self.written_item_ids: List[str] = []
+        self.written_item_ids: list[str] = []
         self.settings = settings
         self.db = Session(bind=db_engine(self.settings))
         self.task = self._query_task(actor_msg_id)
@@ -324,7 +324,7 @@ class CommitBase:
         partitions = self.db.execute(statement).partitions()
 
         # Save any entry point items to publish last.
-        final_items: List[Item] = []
+        final_items: list[Item] = []
 
         wrote_count = 0
 
@@ -338,7 +338,7 @@ class CommitBase:
         ) as bw:
             # Being queuing item batches.
             for partition in partitions:
-                items: List[Item] = []
+                items: list[Item] = []
 
                 # Flatten partition and extract any entry point items.
                 for row in partition:
@@ -498,7 +498,7 @@ def commit(
     publish_id: str,
     env: str,
     from_date: str,
-    commit_mode: Optional[str] = None,
+    commit_mode: str | None = None,
     settings: Settings = Settings(),
 ) -> None:
     actor_msg_id = CurrentMessage.get_current_message().message_id

--- a/tests/app/test_db_session.py
+++ b/tests/app/test_db_session.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
@@ -17,7 +15,7 @@ TEST_UUID = "12345678-1234-5678-1234-567812345678"
 # A testing endpoint which will create an object and then commit,
 # rollback or raise based on params
 def make_publish(
-    request: Request, mode: Optional[str] = None, db: Session = deps.db
+    request: Request, mode: str | None = None, db: Session = deps.db
 ):
     p = Publish(id=TEST_UUID, env="test", state="PENDING")
     db.add(p)

--- a/tests/aws/test_logs.py
+++ b/tests/aws/test_logs.py
@@ -1,6 +1,5 @@
 import io
 from dataclasses import dataclass
-from typing import Optional
 
 import boto3.session
 import botocore
@@ -25,7 +24,7 @@ class AWSResponder:
     # before-send event handler.
     status_code: int = 200
     body: bytes = b""
-    exception: Optional[Exception] = None
+    exception: Exception | None = None
 
     def __call__(self, request: AWSPreparedRequest, **_kwargs):
         if self.exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import base64
 import json
 import os
 from datetime import datetime
-from typing import List
 
 import dramatiq
 import mock
@@ -191,7 +190,7 @@ def fake_publish():
 
 @pytest.fixture
 def auth_header():
-    def _auth_header(roles: List[str] = []):
+    def _auth_header(roles: list[str] = []):
         raw_context = {
             "user": {
                 "authenticated": True,


### PR DESCRIPTION
exodus-gw uses python 3.11. From python 3.10 onwards, type hints can be simplified in various ways, but this was not taken advantage of here. Update all the code to consistently use a more modern form:

- container classes like `typing.List` are no longer needed, the builtin containers like `list`, `dict` can be used directly.

- `Union[x, y]` can be written `x|y` without any imports

- `Optional[x]` can be written `x|None` without any imports

- some features of `typing` have been moved to `collections.abc`