### PR TITLE
Introduce per-user path restrictions [RHELDST-23442]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -118,6 +118,19 @@ class Settings(BaseSettings):
     for validation. E.g., "exodus-migration-md5": "^[0-9a-f]{32}$"
     """
 
+    publish_paths: dict[str, dict[str, list[str]]] = {}
+    """A set of user or service accounts which are only authorized to publish to a
+    particular set of path(s) in a given CDN environment and the regex(es) describing
+    the paths to which the user or service account is authorized to publish. The user or
+    service account will be prevented from publishing to any paths that do not match the
+    defined regular expression(s).
+    E.g., '{"pre": {"fake-user":
+    ["^(/content)?/origin/files/sha256/[0-f]{2}/[0-f]{64}/[^/]{1,300}$"]}}'
+
+    Any user or service account not included in this configuration is considered to have
+    unrestricted publish access (i.e., can publish to any path).
+    """
+
     log_config: dict[str, Any] = {
         "version": 1,
         "incremental": True,


### PR DESCRIPTION
Previously, exodus-gw's publish APIs allowed any authorized user to publish to any paths within a given CDN environment.

Now, it is possible to restrict individual users to publishing to certain paths in a given CDN environment using the publish_paths setting, or the EXODUS_GW_PUBLISH_PATHS environment variable.

An example of the publish paths config:

{
  "pre": {
    "fake-user": [
      "^(/content)?/origin/files/sha256/[0-f]{2}/[0-f]{64}/[^/]{1,300}$"
    ],
  },
  "live": {
    "fake-user": [
      "^(/content)?/origin/files/sha256/[0-f]{2}/[0-f]{64}/[^/]{1,300}$"
    ],
  }
}

Any clients identified in the config are authorized to publish to any path which matches the defined regex. When a client attempts to publish to a path to which does not match the defined regex, they will get a 403 response. Any client which is not included in the publish_paths config will be authorized to publish to any path (assuming they have the necessary publish roles).

This should reduce the risk of conflicts and other issues between exodus-gw users.