### PR TITLE
Record uploader info in S3 metadata during upload [RHELDST-234411]

### DIFF
--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -73,12 +73,12 @@ import textwrap
 
 from fastapi import (
     APIRouter,
+    Depends,
     HTTPException,
     Path,
     Query,
     Request,
     Response,
-    Depends,
 )
 
 from .. import auth, deps

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -39,6 +39,7 @@ async def test_full_upload(
         Metadata={
             "exodus-migration-md5": "94e19d5d30b26306167e9e7bae6b28fd",
             "exodus-migration-src": "original/source",
+            "gw-uploader": "user fake-user",
         },
     )
 


### PR DESCRIPTION
When an object is uploaded to S3, uploading entity(uploader) info i.e user or service account is recorded as "gw-uploader" in the object metadata. This provides an additional source for auditing uploaded content apart from logs.