### PR TITLE
Fix autoindexes treated as phase 1 content [RHELDST-23816]

### DIFF
--- a/exodus_gw/worker/publish.py
+++ b/exodus_gw/worker/publish.py
@@ -325,6 +325,9 @@ class CommitBase:
 
         # Save any entry point items to publish last.
         final_items: list[Item] = []
+        final_basenames = self.settings.entry_point_files + [
+            self.settings.autoindex_filename
+        ]
 
         wrote_count = 0
 
@@ -346,10 +349,7 @@ class CommitBase:
 
                     self.check_item(item)
 
-                    if (
-                        basename(item.web_uri)
-                        in self.settings.entry_point_files
-                    ):
+                    if basename(item.web_uri) in final_basenames:
                         LOG.debug(
                             "Delayed write for %s",
                             item.web_uri,

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -61,6 +61,19 @@ NOW_UTC = str(datetime.now(timezone.utc))
                             }
                         }
                     },
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "web_uri": {"S": "/to/.__exodus_autoindex"},
+                                "object_key": {
+                                    "S": "5891b5b522d5df086d0ff0b110fbd9d2"
+                                    "1bb4fc7163af34d08286a2e846f6be03"
+                                },
+                                "from_date": {"S": "2023-10-04 03:52:02"},
+                                "content_type": {"S": None},
+                            }
+                        }
+                    },
                 ],
             },
         ),
@@ -88,6 +101,14 @@ NOW_UTC = str(datetime.now(timezone.utc))
                         "DeleteRequest": {
                             "Key": {
                                 "web_uri": {"S": "/to/repomd.xml"},
+                                "from_date": {"S": "2023-10-04 03:52:02"},
+                            }
+                        }
+                    },
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "web_uri": {"S": "/to/.__exodus_autoindex"},
                                 "from_date": {"S": "2023-10-04 03:52:02"},
                             }
                         }
@@ -126,7 +147,7 @@ def test_batch_write_item_limit(fake_publish, caplog):
         ddb.batch_write(request)
 
     assert "Cannot process more than 25 items per request" in caplog.text
-    assert str(exc_info.value) == "Request contains too many items (27)"
+    assert "Request contains too many items" in str(exc_info.value)
 
 
 def test_batch_write_deadline(mock_boto3_client, fake_publish, caplog):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,12 @@ def fake_publish():
             publish_id=publish.id,
             updated=datetime(2023, 10, 4, 3, 52, 2),
         ),
+        models.Item(
+            web_uri="/to/.__exodus_autoindex",
+            object_key="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+            publish_id=publish.id,
+            updated=datetime(2023, 10, 4, 3, 52, 2),
+        ),
     ]
     yield publish
 

--- a/tests/worker/test_publish.py
+++ b/tests/worker/test_publish.py
@@ -143,7 +143,7 @@ def test_commit_write_items_fail(
         "Task 8d8a4692-c89b-4b57-840f-b3f0166148d2 encountered an error"
         in caplog.text
     )
-    assert "Rolling back 3 item(s) due to error" in caplog.text
+    assert "Rolling back 2 item(s) due to error" in caplog.text
     # It should've set task state to FAILED.
     db.refresh(task)
     assert task.state == "FAILED"
@@ -501,16 +501,15 @@ def test_commit_phase1(
         {"dirty": False, "web_uri": "/some/path"},
         # the unresolved link is not yet written and therefore remains dirty
         {"dirty": True, "web_uri": "/some/path/to/link-src"},
-        # autoindex was written and hence is not dirty
-        # (This is actually a bug! RHELDST-23816)
-        {"dirty": False, "web_uri": "/to/.__exodus_autoindex"},
-        # repomd.xml is not yet written and therefore remains dirty
+        # autoindex and repomd.xml are both entrypoints, not yet written,
+        # and therefore remain dirty
+        {"dirty": True, "web_uri": "/to/.__exodus_autoindex"},
         {"dirty": True, "web_uri": "/to/repomd.xml"},
     ]
 
     # It should have told us how many it wrote and how many remain
     assert (
-        "Phase 1: committed 3 items, phase 2: 1 items remaining" in caplog.text
+        "Phase 1: committed 2 items, phase 2: 2 items remaining" in caplog.text
     )
 
     # Let's do the same commit again...
@@ -528,7 +527,7 @@ def test_commit_phase1(
     # This time there should not have been any phase1 items processed at all,
     # as none of them were dirty.
     assert (
-        "Phase 1: committed 0 items, phase 2: 1 items remaining" in caplog.text
+        "Phase 1: committed 0 items, phase 2: 2 items remaining" in caplog.text
     )
 
     # And it should NOT have invoked the autoindex enricher in either commit

--- a/tests/worker/test_publish.py
+++ b/tests/worker/test_publish.py
@@ -143,7 +143,7 @@ def test_commit_write_items_fail(
         "Task 8d8a4692-c89b-4b57-840f-b3f0166148d2 encountered an error"
         in caplog.text
     )
-    assert "Rolling back 2 item(s) due to error" in caplog.text
+    assert "Rolling back 3 item(s) due to error" in caplog.text
     # It should've set task state to FAILED.
     db.refresh(task)
     assert task.state == "FAILED"
@@ -187,7 +187,7 @@ def test_commit_write_entry_point_items_fail(
     )
     # It should've logged messages.
     assert "Exception while submitting batch write(s)" in caplog.text
-    assert "Rolling back 3 item(s) due to error" in caplog.text
+    assert "Rolling back 4 item(s) due to error" in caplog.text
     # It should've set task state to FAILED.
     db.refresh(task)
     assert task.state == "FAILED"
@@ -445,7 +445,9 @@ def test_commit_phase1(
     db.refresh(task)
 
     # All the items should initially be dirty.
-    assert [i.dirty for i in fake_publish.items] == [True, True, True, True]
+    assert [i.dirty for i in fake_publish.items] == [True] * len(
+        fake_publish.items
+    )
 
     # Let's say that DynamoDB write initially fails.
     mock_write_batch.side_effect = RuntimeError("simulated error")
@@ -499,13 +501,16 @@ def test_commit_phase1(
         {"dirty": False, "web_uri": "/some/path"},
         # the unresolved link is not yet written and therefore remains dirty
         {"dirty": True, "web_uri": "/some/path/to/link-src"},
+        # autoindex was written and hence is not dirty
+        # (This is actually a bug! RHELDST-23816)
+        {"dirty": False, "web_uri": "/to/.__exodus_autoindex"},
         # repomd.xml is not yet written and therefore remains dirty
         {"dirty": True, "web_uri": "/to/repomd.xml"},
     ]
 
     # It should have told us how many it wrote and how many remain
     assert (
-        "Phase 1: committed 2 items, phase 2: 1 items remaining" in caplog.text
+        "Phase 1: committed 3 items, phase 2: 1 items remaining" in caplog.text
     )
 
     # Let's do the same commit again...


### PR DESCRIPTION
The automatically generated directory listings are a form of entry point
and ought to be treated as phase 2 content, like the rest of the entry
points. If this is not done, it means that (e.g.) yum repodata and the
directory listings generated from it are not guaranteed to be committed
together, and so may sometimes become out of sync with each other.

Tweak the publish code to treat these files in the same way as any other
entry point file.