### PR TITLE
dev env: refresh sidecar version

### DIFF
--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -13,7 +13,7 @@ After=network-online.target
 EnvironmentFile=-%E/exodus-gw-dev/.env
 Environment=EXODUS_GW_HTTP_PORT=8000
 Environment=EXODUS_GW_HTTPS_PORT=8010
-Environment=EXODUS_GW_SIDECAR_IMAGE=images.paas.redhat.com/it-platform/platform-sidecar:2.0.4
+Environment=EXODUS_GW_SIDECAR_IMAGE=images.paas.redhat.com/it-platform/platform-sidecar:3.2.9.7df47cc
 
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
@@ -25,6 +25,7 @@ server.port: ${EXODUS_GW_HTTPS_PORT}\n\
 com.redhat.api.platform:\n\
  http.server:\n\
   proxy.target: http://localhost:${EXODUS_GW_HTTP_PORT}\n\
+  use-default-authorities: false\n\
   public-certificate-x509-pem:\
 |\n$(sed -r -e 's|^|    |' %E/exodus-gw-dev/service.pem)\n\
   private-key-pkcs8-pem:\


### PR DESCRIPTION
Use a newer version of sidecar, the same as used in production. Set "use-default-authorities: false", which became necessary if using a development CA as done here.