### PR TITLE
revert (partial): write compressed configuration [RHELDST-25461]

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -1,7 +1,7 @@
 import gzip
 import json
 import logging
-from base64 import b64decode, b64encode
+from base64 import b64decode
 from datetime import datetime
 from itertools import islice
 from threading import Lock
@@ -161,11 +161,7 @@ class DynamoDB:
                         "Item": {
                             "from_date": {"S": self.from_date},
                             "config_id": {"S": "exodus-config"},
-                            "config": {
-                                "B": b64encode(
-                                    gzip.compress(json.dumps(config).encode())
-                                ).decode()
-                            },
+                            "config": {"S": json.dumps(config)},
                         }
                     }
                 },

--- a/exodus_gw/models/dramatiq.py
+++ b/exodus_gw/models/dramatiq.py
@@ -8,6 +8,11 @@ from sqlalchemy.types import Uuid
 
 from .base import Base
 
+# Avoid pylint complaining about:
+# E1136: Value 'Mapped' is unsubscriptable
+# These errors started to appear around 2024-08, and they're wrong.
+# pylint: disable=unsubscriptable-object
+
 
 class DramatiqMessage(Base):
     # This table holds queued messages.

--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -54,11 +54,7 @@ def test_deploy_config(
                     "Item": {
                         "from_date": {"S": NOW_UTC},
                         "config_id": {"S": "exodus-config"},
-                        "config": {
-                            "B": b64encode(
-                                gzip.compress(json.dumps(fake_config).encode())
-                            ).decode()
-                        },
+                        "config": {"S": json.dumps(fake_config)},
                     }
                 }
             },
@@ -158,13 +154,7 @@ def test_deploy_config_with_flush(
                     "Item": {
                         "from_date": {"S": NOW_UTC},
                         "config_id": {"S": "exodus-config"},
-                        "config": {
-                            "B": b64encode(
-                                gzip.compress(
-                                    json.dumps(updated_config).encode()
-                                )
-                            ).decode()
-                        },
+                        "config": {"S": json.dumps(updated_config)},
                     }
                 }
             },


### PR DESCRIPTION
This commit partially reverts db4a3443feadd74cb; specifically, it disables the writing of compressed config and reverts back to writing JSON config as before.

This is being reverted due to an issue noticed during testing. It seems that the written items are ending up with *two* layers of base64 encoding, which is not intended.
The boto docs[1] use base64 strings as example arguments, giving the impression the caller is expected to take care of base64 encoding, but in fact botocore internally does the encoding; if the client also encodes, we end up with two layers of encoding.

There is also a bug filed relating to this[2].

The code here still seems to "work" since the same mistake is made on both the writing and reading end, but the goal is to make the config smaller and having double-encoding works against that.

It should be easy enough to fix, but I'd like some time to confirm my understanding of how it works, check whether exodus-lambda needs a fix and also check whether localstack and AWS are behaving the same. Hence I'll revert this for now and keep writing the old style of config.

[1] https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/client/put_item.html
[2] https://github.com/aws/aws-cli/issues/1097