### PR TITLE
Write compressed config, round 2 [RHELDST-25461]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,11 +54,7 @@ def fake_dynamodb_query(
         assert Limit == 1
         config_json = json.dumps(fake_config)
         if binary_config:
-            config_value = {
-                "B": base64.b64encode(
-                    gzip.compress(config_json.encode())
-                ).decode()
-            }
+            config_value = {"B": gzip.compress(config_json.encode())}
         else:
             config_value = {"S": config_json}
         return {

--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -54,7 +54,11 @@ def test_deploy_config(
                     "Item": {
                         "from_date": {"S": NOW_UTC},
                         "config_id": {"S": "exodus-config"},
-                        "config": {"S": json.dumps(fake_config)},
+                        "config": {
+                            "B": gzip.compress(
+                                json.dumps(fake_config).encode()
+                            )
+                        },
                     }
                 }
             },
@@ -154,7 +158,11 @@ def test_deploy_config_with_flush(
                     "Item": {
                         "from_date": {"S": NOW_UTC},
                         "config_id": {"S": "exodus-config"},
-                        "config": {"S": json.dumps(updated_config)},
+                        "config": {
+                            "B": gzip.compress(
+                                json.dumps(updated_config).encode()
+                            )
+                        },
                     }
                 }
             },


### PR DESCRIPTION
This commit re-enables the writing of compressed config, this time without the extraneous layer of base64 encoding, as this is understood to be done implicitly by botocore.

Must be merged *after* deployment of corresponding exodus-lambda change: https://github.com/release-engineering/exodus-lambda/pull/589