### PR TITLE
Fix rhui_alias resolution during cache flush [RHELDST-26143]

### DIFF
--- a/tests/aws/test_uri_alias.py
+++ b/tests/aws/test_uri_alias.py
@@ -14,14 +14,20 @@ from exodus_gw.aws.util import uri_alias
                 ("/content/origin", "/origin"),
                 ("/origin/rpm", "/origin/rpms"),
             ],
-            "/origin/rpms/path/to/file.iso",
+            [
+                "/origin/rpms/path/to/file.iso",
+                "/content/origin/rpms/path/to/file.iso",
+            ],
         ),
         (
             "/content/dist/rhel8/8/path/to/file.rpm",
             [
                 ("/content/dist/rhel8/8", "/content/dist/rhel8/8.5"),
             ],
-            "/content/dist/rhel8/8.5/path/to/file.rpm",
+            [
+                "/content/dist/rhel8/8.5/path/to/file.rpm",
+                "/content/dist/rhel8/8/path/to/file.rpm",
+            ],
         ),
     ],
     ids=["origin", "releasever"],
@@ -30,7 +36,104 @@ def test_uri_alias(input, aliases, output, caplog):
     caplog.set_level(DEBUG, logger="exodus-gw")
     assert uri_alias(input, aliases) == output
     assert (
-        f'"message": "Resolved alias:\\n\\tsrc: {input}\\n\\tdest: {output}", '
+        f'"message": "Resolved alias:\\n\\tsrc: {input}\\n\\tdest: {output[0]}", '
         '"event": "publish", '
         '"success": true' in caplog.text
+    )
+
+
+def test_uri_alias_multi_level_write():
+    # uri_alias should support resolving aliases multiple levels deep
+    # and return values in the right order, using single-direction aliases
+    # (as is typical in the write case)
+    uri = "/content/other/1/repo"
+    aliases = [
+        # The data here is made up as there is not currently any identified
+        # realistic scenario having multi-level aliases during write.
+        ("/content/testproduct/1", "/content/testproduct/1.1.0"),
+        ("/content/other", "/content/testproduct"),
+    ]
+
+    out = uri_alias(uri, aliases)
+    assert out == [
+        "/content/testproduct/1.1.0/repo",
+        "/content/testproduct/1/repo",
+        "/content/other/1/repo",
+    ]
+
+
+def test_uri_alias_multi_level_flush():
+    # uri_alias should support resolving aliases multiple levels deep
+    # and return values in the right order, using bi-directional aliases
+    # (as is typical in the flush case).
+    #
+    # This data is realistic for the common case where releasever
+    # and rhui aliases are both in play.
+
+    uri = "/content/dist/rhel8/8/some-repo/"
+    aliases = [
+        # The caller is providing aliases in both src => dest and
+        # dest => src directions, as in the "cache flush" case.
+        ("/content/dist/rhel8/8", "/content/dist/rhel8/8.8"),
+        ("/content/dist/rhel8/8.8", "/content/dist/rhel8/8"),
+        ("/content/dist/rhel8/rhui", "/content/dist/rhel8"),
+        ("/content/dist/rhel8", "/content/dist/rhel8/rhui"),
+    ]
+
+    out = uri_alias(uri, aliases)
+    # We don't verify the order here because, with bi-directional aliases
+    # provided, it does not really make sense to consider either side of
+    # the alias as "deeper" than the other.
+    assert sorted(out) == sorted(
+        [
+            # It should return the repo on both sides of the
+            # releasever alias...
+            "/content/dist/rhel8/8/some-repo/",
+            "/content/dist/rhel8/8.8/some-repo/",
+            # And *also* on both sides of the releasever alias, beyond
+            # the RHUI alias.
+            "/content/dist/rhel8/rhui/8/some-repo/",
+            "/content/dist/rhel8/rhui/8.8/some-repo/",
+        ]
+    )
+
+
+def test_uri_alias_limit(caplog: pytest.LogCaptureFixture):
+    # uri_alias applies some limit on the alias resolution depth.
+    #
+    # This test exists to exercise the path of code intended to
+    # prevent runaway recursion. There is no known way how to
+    # actually trigger runaway recursion, so we are just providing
+    # an unrealistic config with more levels of alias than are
+    # actually used on production.
+
+    uri = "/path/a/repo"
+    aliases = [
+        ("/path/a", "/path/b"),
+        ("/path/b", "/path/c"),
+        ("/path/c", "/path/d"),
+        ("/path/d", "/path/e"),
+        ("/path/e", "/path/f"),
+        ("/path/f", "/path/g"),
+        ("/path/g", "/path/h"),
+        ("/path/h", "/path/i"),
+    ]
+
+    out = uri_alias(uri, aliases)
+
+    # It should have stopped resolving aliases at some point.
+    # Note that exactly where it stops is rather abitrary, the
+    # max depth currently is simply hardcoded.
+    assert out == [
+        "/path/f/repo",
+        "/path/e/repo",
+        "/path/d/repo",
+        "/path/c/repo",
+        "/path/b/repo",
+        "/path/a/repo",
+    ]
+
+    # It should have warned us about this.
+    assert (
+        "Aliases too deeply nested, bailing out at /path/f/repo" in caplog.text
     )

--- a/tests/worker/test_cdn_cache.py
+++ b/tests/worker/test_cdn_cache.py
@@ -193,7 +193,7 @@ cache_flush_arl_templates =
                                 {"src": "/path/one", "dest": "/path/one-dest"},
                             ],
                             "rhui_alias": [
-                                {"src": "/path/two", "dest": "/path/two-dest"},
+                                {"src": "/path/rhui/two", "dest": "/path/two"},
                             ],
                         }
                     )
@@ -211,7 +211,7 @@ cache_flush_arl_templates =
             # - alias resolution
             # - treeinfo special case
             "/path/one/repodata/repomd.xml",
-            "path/two/listing",
+            "path/rhui/two/listing",
             "third/path",
             "/some/misc/treeinfo",
             "/some/kickstart/treeinfo",
@@ -244,14 +244,14 @@ cache_flush_arl_templates =
         # Used the ARL templates. Note the different TTL values
         # for different paths, and also the paths both before and
         # after alias resolution are flushed.
-        "S/=/123/4567/10m/cdn1.example.com/path/two-dest/listing cid=///",
+        "S/=/123/4567/10m/cdn1.example.com/path/rhui/two/listing cid=///",
         "S/=/123/4567/10m/cdn1.example.com/path/two/listing cid=///",
         # note only the kickstart treeinfo appears, the other is filtered.
         "S/=/123/4567/30d/cdn1.example.com/some/kickstart/treeinfo cid=///",
         "S/=/123/4567/30d/cdn1.example.com/third/path cid=///",
         "S/=/123/4567/4h/cdn1.example.com/path/one-dest/repodata/repomd.xml cid=///",
         "S/=/123/4567/4h/cdn1.example.com/path/one/repodata/repomd.xml cid=///",
-        "S/=/234/6677/10m/cdn2.example.com/other/path/two-dest/listing x/y/z",
+        "S/=/234/6677/10m/cdn2.example.com/other/path/rhui/two/listing x/y/z",
         "S/=/234/6677/10m/cdn2.example.com/other/path/two/listing x/y/z",
         "S/=/234/6677/30d/cdn2.example.com/other/some/kickstart/treeinfo x/y/z",
         "S/=/234/6677/30d/cdn2.example.com/other/third/path x/y/z",
@@ -260,14 +260,14 @@ cache_flush_arl_templates =
         # Used the CDN URL which didn't have a leading path.
         "https://cdn1.example.com/path/one-dest/repodata/repomd.xml",
         "https://cdn1.example.com/path/one/repodata/repomd.xml",
-        "https://cdn1.example.com/path/two-dest/listing",
+        "https://cdn1.example.com/path/rhui/two/listing",
         "https://cdn1.example.com/path/two/listing",
         "https://cdn1.example.com/some/kickstart/treeinfo",
         "https://cdn1.example.com/third/path",
         # Used the CDN URL which had a leading path.
         "https://cdn2.example.com/root/path/one-dest/repodata/repomd.xml",
         "https://cdn2.example.com/root/path/one/repodata/repomd.xml",
-        "https://cdn2.example.com/root/path/two-dest/listing",
+        "https://cdn2.example.com/root/path/rhui/two/listing",
         "https://cdn2.example.com/root/path/two/listing",
         "https://cdn2.example.com/root/some/kickstart/treeinfo",
         "https://cdn2.example.com/root/third/path",

--- a/tests/worker/test_publish.py
+++ b/tests/worker/test_publish.py
@@ -102,11 +102,16 @@ def test_commit(
     )
     assert sorted([(pp.env, pp.web_uri) for pp in published_paths]) == sorted(
         [
-            # Note that both sides of the 1 alias are recorded.
+            # Note that both sides of the 1 alias are recorded, including
+            # beyond the RHUI alias.
             ("test", "/content/testproduct/1/repo/"),
             ("test", "/content/testproduct/1.1.0/repo/"),
             ("test", "/content/testproduct/1/repo/repomd.xml"),
             ("test", "/content/testproduct/1.1.0/repo/repomd.xml"),
+            ("test", "/content/testproduct/rhui/1/repo/"),
+            ("test", "/content/testproduct/rhui/1/repo/repomd.xml"),
+            ("test", "/content/testproduct/rhui/1.1.0/repo/"),
+            ("test", "/content/testproduct/rhui/1.1.0/repo/repomd.xml"),
         ]
     )
 


### PR DESCRIPTION
It was intended to take RHUI aliases into account during cache flush, but this was not implemented correctly.

The main issue was that alias resolution was only implemented in the direction of (src => dest), but in the case of RHUI, we are always publishing content on the destination (non-RHUI) side of the alias. Hence we need to also consider the aliases in the (dest => src) direction to figure out that the src (RHUI) side of the alias is relevant for cache flush.

A second issue was that, if multiple aliases were involved in a path, we would not flush cache for all of them. This couldn't work because the uri_alias function was designed to return only a single value, after resolution of all aliases. When multiple aliases are in play, content is actually accessible at all the paths calculated during each step of the resolution, so we need to keep track of intermediate paths and flush cache for all of them.

This now behaves correctly in the typical case of both $releasever and RHUI aliases being in play, e.g. for /content/dist/rhel9/9/foo, it will now correctly calculate the 4 typical paths under which content is accessible:

- /content/dist/rhel9/9/foo
- /content/dist/rhel9/9.4/foo
- /content/dist/rhel9/rhui/9/foo
- /content/dist/rhel9/rhui/9.4/foo