### PR TITLE
Introduce cache flush rules [RHELDST-26144]

### DIFF
--- a/tests/worker/test_cdn_cache.py
+++ b/tests/worker/test_cdn_cache.py
@@ -154,14 +154,33 @@ config_table = my-config
 cdn_url = http://localhost:8049/_/cookie
 cdn_key_id = XXXXXXXXXXXXXX
 
-cache_flush_urls =
-    https://cdn1.example.com
-    https://cdn2.example.com/root
+cache_flush_rules =
+    cdn1
+    cdn2
+    repomd
 
-cache_flush_arl_templates =
+[cache_flush.cdn1]
+templates =
+    https://cdn1.example.com
     S/=/123/4567/{ttl}/cdn1.example.com/{path} cid=///
+excludes =
+    /not-cdn1/
+    /also-not-cdn1/
+
+[cache_flush.cdn2]
+templates =
+    https://cdn2.example.com/root
     S/=/234/6677/{ttl}/cdn2.example.com/other/{path} x/y/z
 
+[cache_flush.repomd]
+templates =
+    S/=/234/6677/{ttl}/special-repomd-template/{path} x/y/z
+# This contrived rule applies to repomd.xml files, but excludes
+# one path to test includes and excludes together.
+includes =
+    /repomd\\.xml$
+excludes =
+    /also
 """
     )
 
@@ -211,6 +230,8 @@ cache_flush_arl_templates =
             # - alias resolution
             # - treeinfo special case
             "/path/one/repodata/repomd.xml",
+            "path/not-cdn1/repodata/repomd.xml",
+            "path/also-not-cdn1/repodata/repomd.xml",
             "path/rhui/two/listing",
             "third/path",
             "/some/misc/treeinfo",
@@ -240,35 +261,145 @@ cache_flush_arl_templates =
 
     # It should have flushed cache for all the expected URLs,
     # using both the CDN root URLs and the ARL templates
-    assert sorted(fp_client._purged_urls) == [
-        # Used the ARL templates. Note the different TTL values
-        # for different paths, and also the paths both before and
-        # after alias resolution are flushed.
-        "S/=/123/4567/10m/cdn1.example.com/path/rhui/two/listing cid=///",
-        "S/=/123/4567/10m/cdn1.example.com/path/two/listing cid=///",
-        # note only the kickstart treeinfo appears, the other is filtered.
-        "S/=/123/4567/30d/cdn1.example.com/some/kickstart/treeinfo cid=///",
-        "S/=/123/4567/30d/cdn1.example.com/third/path cid=///",
-        "S/=/123/4567/4h/cdn1.example.com/path/one-dest/repodata/repomd.xml cid=///",
-        "S/=/123/4567/4h/cdn1.example.com/path/one/repodata/repomd.xml cid=///",
-        "S/=/234/6677/10m/cdn2.example.com/other/path/rhui/two/listing x/y/z",
-        "S/=/234/6677/10m/cdn2.example.com/other/path/two/listing x/y/z",
-        "S/=/234/6677/30d/cdn2.example.com/other/some/kickstart/treeinfo x/y/z",
-        "S/=/234/6677/30d/cdn2.example.com/other/third/path x/y/z",
-        "S/=/234/6677/4h/cdn2.example.com/other/path/one-dest/repodata/repomd.xml x/y/z",
-        "S/=/234/6677/4h/cdn2.example.com/other/path/one/repodata/repomd.xml x/y/z",
-        # Used the CDN URL which didn't have a leading path.
-        "https://cdn1.example.com/path/one-dest/repodata/repomd.xml",
-        "https://cdn1.example.com/path/one/repodata/repomd.xml",
-        "https://cdn1.example.com/path/rhui/two/listing",
-        "https://cdn1.example.com/path/two/listing",
-        "https://cdn1.example.com/some/kickstart/treeinfo",
-        "https://cdn1.example.com/third/path",
-        # Used the CDN URL which had a leading path.
-        "https://cdn2.example.com/root/path/one-dest/repodata/repomd.xml",
-        "https://cdn2.example.com/root/path/one/repodata/repomd.xml",
-        "https://cdn2.example.com/root/path/rhui/two/listing",
-        "https://cdn2.example.com/root/path/two/listing",
-        "https://cdn2.example.com/root/some/kickstart/treeinfo",
-        "https://cdn2.example.com/root/third/path",
-    ]
+    assert sorted(fp_client._purged_urls) == sorted(
+        [
+            # Used the ARL templates. Note the different TTL values
+            # for different paths, and also the paths both before and
+            # after alias resolution are flushed.
+            "S/=/123/4567/10m/cdn1.example.com/path/rhui/two/listing cid=///",
+            "S/=/123/4567/10m/cdn1.example.com/path/two/listing cid=///",
+            # note only the kickstart treeinfo appears, the other is filtered.
+            "S/=/123/4567/30d/cdn1.example.com/some/kickstart/treeinfo cid=///",
+            "S/=/123/4567/30d/cdn1.example.com/third/path cid=///",
+            "S/=/123/4567/4h/cdn1.example.com/path/one-dest/repodata/repomd.xml cid=///",
+            "S/=/123/4567/4h/cdn1.example.com/path/one/repodata/repomd.xml cid=///",
+            "S/=/234/6677/10m/cdn2.example.com/other/path/rhui/two/listing x/y/z",
+            "S/=/234/6677/10m/cdn2.example.com/other/path/two/listing x/y/z",
+            "S/=/234/6677/30d/cdn2.example.com/other/some/kickstart/treeinfo x/y/z",
+            "S/=/234/6677/30d/cdn2.example.com/other/third/path x/y/z",
+            "S/=/234/6677/4h/cdn2.example.com/other/path/one-dest/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/cdn2.example.com/other/path/one/repodata/repomd.xml x/y/z",
+            # note the following two repomd.xml did NOT get flushed against cdn1.example.com
+            # due to matching 'excludes'
+            "S/=/234/6677/4h/cdn2.example.com/other/path/not-cdn1/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/cdn2.example.com/other/path/also-not-cdn1/repodata/repomd.xml x/y/z",
+            # special rule just for repomd.xml was activated for these paths.
+            # Note the "also-not-cdn1" path was filtered by an exclude.
+            "S/=/234/6677/4h/special-repomd-template/path/not-cdn1/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/special-repomd-template/path/one-dest/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/special-repomd-template/path/one/repodata/repomd.xml x/y/z",
+            # Used the CDN URL which didn't have a leading path.
+            "https://cdn1.example.com/path/one-dest/repodata/repomd.xml",
+            "https://cdn1.example.com/path/one/repodata/repomd.xml",
+            "https://cdn1.example.com/path/rhui/two/listing",
+            "https://cdn1.example.com/path/two/listing",
+            "https://cdn1.example.com/some/kickstart/treeinfo",
+            "https://cdn1.example.com/third/path",
+            # Used the CDN URL which had a leading path.
+            "https://cdn2.example.com/root/path/one-dest/repodata/repomd.xml",
+            "https://cdn2.example.com/root/path/one/repodata/repomd.xml",
+            "https://cdn2.example.com/root/path/not-cdn1/repodata/repomd.xml",
+            "https://cdn2.example.com/root/path/also-not-cdn1/repodata/repomd.xml",
+            "https://cdn2.example.com/root/path/rhui/two/listing",
+            "https://cdn2.example.com/root/path/two/listing",
+            "https://cdn2.example.com/root/some/kickstart/treeinfo",
+            "https://cdn2.example.com/root/third/path",
+        ]
+    )
+
+
+def test_flush_cdn_cache_legacy_config(
+    db: Session,
+    caplog: pytest.LogCaptureFixture,
+    mock_boto3_client,
+    fake_message_id: str,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """flush_cdn_cache performs expected cache flushes in
+    a typical usage scenario where old-style config (no "rules")
+    has been used in exodus-gw.ini.
+    """
+
+    # Write an ini file with some fastpurge stuff under our control.
+    conf_path = tmp_path / "exodus-gw.ini"
+    conf_path.write_text(
+        """
+[env.cachetest]
+aws_profile = cachetest
+bucket = my-bucket
+table = my-table
+config_table = my-config
+
+cdn_url = http://localhost:8049/_/cookie
+cdn_key_id = XXXXXXXXXXXXXX
+
+cache_flush_urls =
+    https://cdn1.example.com
+    https://cdn2.example.com
+
+cache_flush_arl_templates =
+    S/=/234/6677/{ttl}/cdn1.example.com/other/{path} x/y/z
+    S/=/234/6677/{ttl}/cdn2.example.com/other/{path} x/y/z
+"""
+    )
+
+    # Make load_settings use our config file above.
+    monkeypatch.setenv("EXODUS_GW_INI_PATH", str(conf_path))
+
+    # Provide some fastpurge credentials
+    monkeypatch.setenv("EXODUS_GW_FASTPURGE_HOST_CACHETEST", "fphost")
+    monkeypatch.setenv("EXODUS_GW_FASTPURGE_CLIENT_TOKEN_CACHETEST", "ctok")
+    monkeypatch.setenv("EXODUS_GW_FASTPURGE_CLIENT_SECRET_CACHETEST", "csec")
+    monkeypatch.setenv("EXODUS_GW_FASTPURGE_ACCESS_TOKEN_CACHETEST", "atok")
+
+    settings = load_settings()
+
+    task = Task(id=fake_message_id)
+    task.state = "NOT_STARTED"
+    db.add(task)
+    db.commit()
+
+    # It should run to completion...
+    flush_cdn_cache(
+        paths=[
+            "/path/to/repo1/repodata/repomd.xml",
+            "/path/to/repo2/repodata/repomd.xml",
+        ],
+        env="cachetest",
+        settings=settings,
+    )
+
+    # The task should have succeeded
+    db.refresh(task)
+    assert task.state == "COMPLETE"
+
+    # Check how it used the fastpurge client
+    fp_client = FakeFastPurgeClient.INSTANCE
+
+    # It should have created a client
+    assert fp_client
+
+    # It should have provided the credentials from env vars
+    assert fp_client._kwargs["auth"] == {
+        "access_token": "atok",
+        "client_secret": "csec",
+        "client_token": "ctok",
+        "host": "fphost",
+    }
+
+    # It should have flushed cache for all the expected URLs
+    assert sorted(fp_client._purged_urls) == sorted(
+        [
+            # This is flat legacy config which applies the same templates to all paths,
+            # so cdn1 and cdn2 get exactly the same content flushed.
+            "S/=/234/6677/4h/cdn1.example.com/other/path/to/repo1/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/cdn1.example.com/other/path/to/repo2/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/cdn2.example.com/other/path/to/repo1/repodata/repomd.xml x/y/z",
+            "S/=/234/6677/4h/cdn2.example.com/other/path/to/repo2/repodata/repomd.xml x/y/z",
+            "https://cdn1.example.com/path/to/repo1/repodata/repomd.xml",
+            "https://cdn1.example.com/path/to/repo2/repodata/repomd.xml",
+            "https://cdn2.example.com/path/to/repo1/repodata/repomd.xml",
+            "https://cdn2.example.com/path/to/repo2/repodata/repomd.xml",
+        ]
+    )


### PR DESCRIPTION
This change extends the cache flush config to support separate rules with different templates, enabled via patterns matched against candidate paths for flush.

The goal here is to reduce the amount of unnecessarily flushed URLs/ARLs. In typical scenarios, we have three different CDN hosts in front of a single exodus-gw environment, with certain subtrees being only available from certain hosts. With the flat config structure existing before this change, we had no choice but to flush cache keys for all three of them for every path, even though each path is only relevant to one of the hosts. Hence, we were flushing 3x as many ARLs as we should be.

With this change we can update the configuration to only flush cache for the necessary CDN host for each subtree, significantly cutting down the number of cache keys for flush.

This commit is backwards-compatible with the old config style, so it can be safely deployed before updating exodus-gw.ini.