### PR TITLE
Add exclusions for aliases [RHELDST-26013]

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -46,14 +46,21 @@ class DynamoDB:
                     self._definitions = self.query_definitions()
         return self._definitions
 
-    def _aliases(self, alias_types: list[str]) -> list[tuple[str, str, list[str]]]:
+    def _aliases(
+        self, alias_types: list[str]
+    ) -> list[tuple[str, str, list[str]]]:
         out: list[tuple[str, str, list[str]]] = []
 
         for k, v in self.definitions.items():
             if k in alias_types:
                 for alias in v:
-                    out.append((alias["src"], alias["dest"],
-                                alias.get("exclude_paths") or []))
+                    out.append(
+                        (
+                            alias["src"],
+                            alias["dest"],
+                            alias.get("exclude_paths") or [],
+                        )
+                    )
 
         return out
 
@@ -129,7 +136,9 @@ class DynamoDB:
         # this alias. If we don't traverse the alias from dest => src then we
         # will miss the fact that /content/dist/rhel8/rhui paths should also
         # have cache flushed.
-        out = out + [(dest, src, exclusions) for (src, dest, exclusions) in out]
+        out = out + [
+            (dest, src, exclusions) for (src, dest, exclusions) in out
+        ]
 
         return out
 

--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -161,7 +161,9 @@ class RequestReader:
         return cls(request)
 
 
-def uri_alias(uri: str, aliases: list[tuple[str, str, list[str]]]) -> list[str]:
+def uri_alias(
+    uri: str, aliases: list[tuple[str, str, list[str]]]
+) -> list[str]:
     # Resolve every alias between paths within the uri (e.g.
     # allow RHUI paths to be aliased to non-RHUI).
     #
@@ -222,12 +224,13 @@ def uri_alias_recurse(
             # Used to replicate old NetStorage-compatible behaviour. This will
             # typically match non-rpm paths, such as /images/ or /isos/
             if any([re.search(exclusion, uri) for exclusion in exclude_paths]):
-                LOG.debug("Aliasing for %s was not applied as it matches one "
-                          "of the following exclusion paths: %s.",
-                          uri,
-                          ",".join(exclude_paths),
-                          extra={"event": "publish", "success": True},
-                          )
+                LOG.debug(
+                    "Aliasing for %s was not applied as it matches one "
+                    "of the following exclusion paths: %s.",
+                    uri,
+                    ",".join(exclude_paths),
+                    extra={"event": "publish", "success": True},
+                )
                 continue
 
             new_uri = uri.replace(src, dest, 1)

--- a/exodus_gw/routers/config.py
+++ b/exodus_gw/routers/config.py
@@ -43,6 +43,12 @@ ALIAS_SCHEMA = {
                 "pattern": PATH_PATTERN,
                 "description": "Target of the alias, relative to CDN root.",
             },
+            "exclude_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Paths for which alias will not be resolved, "
+                               "treated as an unanchored regex."
+            }
         },
     },
     "uniqueItems": True,
@@ -134,19 +140,30 @@ def config_post(
                     },
                 },
                 "origin_alias": [
-                    {"src": "/content/origin", "dest": "/origin"},
-                    {"src": "/origin/rpm", "dest": "/origin/rpms"},
+                    {
+                        "src": "/content/origin",
+                        "dest": "/origin",
+                        "exclude_paths": []
+                    },
+                    {
+                        "src": "/origin/rpm",
+                        "dest": "/origin/rpms",
+                        "exclude_paths": ["/iso/"]
+                    },
                 ],
                 "releasever_alias": [
                     {
                         "dest": "/content/dist/rhel8/8.5",
                         "src": "/content/dist/rhel8/8",
+                        "exclude_paths": ["/files/", "/images/", "/iso/"]
                     },
+
                 ],
                 "rhui_alias": [
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
+                        "exclude_paths": ["/files/", "/images/", "/iso/"]
                     },
                 ],
             }

--- a/exodus_gw/routers/config.py
+++ b/exodus_gw/routers/config.py
@@ -47,8 +47,8 @@ ALIAS_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Paths for which alias will not be resolved, "
-                               "treated as an unanchored regex."
-            }
+                "treated as an unanchored regex.",
+            },
         },
     },
     "uniqueItems": True,
@@ -143,27 +143,26 @@ def config_post(
                     {
                         "src": "/content/origin",
                         "dest": "/origin",
-                        "exclude_paths": []
+                        "exclude_paths": [],
                     },
                     {
                         "src": "/origin/rpm",
                         "dest": "/origin/rpms",
-                        "exclude_paths": ["/iso/"]
+                        "exclude_paths": ["/iso/"],
                     },
                 ],
                 "releasever_alias": [
                     {
                         "dest": "/content/dist/rhel8/8.5",
                         "src": "/content/dist/rhel8/8",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"]
+                        "exclude_paths": ["/files/", "/images/", "/iso/"],
                     },
-
                 ],
                 "rhui_alias": [
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"]
+                        "exclude_paths": ["/files/", "/images/", "/iso/"],
                     },
                 ],
             }

--- a/exodus_gw/routers/deploy.py
+++ b/exodus_gw/routers/deploy.py
@@ -59,27 +59,26 @@ def deploy_config(
                     {
                         "src": "/content/origin",
                         "dest": "/origin",
-                        "exclude_paths": []
+                        "exclude_paths": [],
                     },
                     {
                         "src": "/origin/rpm",
                         "dest": "/origin/rpms",
-                        "exclude_paths": ["/iso/"]
+                        "exclude_paths": ["/iso/"],
                     },
                 ],
                 "releasever_alias": [
                     {
                         "dest": "/content/dist/rhel8/8.5",
                         "src": "/content/dist/rhel8/8",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"]
+                        "exclude_paths": ["/files/", "/images/", "/iso/"],
                     },
-
                 ],
                 "rhui_alias": [
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"]
+                        "exclude_paths": ["/files/", "/images/", "/iso/"],
                     },
                 ],
             }

--- a/exodus_gw/routers/deploy.py
+++ b/exodus_gw/routers/deploy.py
@@ -56,19 +56,30 @@ def deploy_config(
                     },
                 },
                 "origin_alias": [
-                    {"src": "/content/origin", "dest": "/origin"},
-                    {"src": "/origin/rpm", "dest": "/origin/rpms"},
+                    {
+                        "src": "/content/origin",
+                        "dest": "/origin",
+                        "exclude_paths": []
+                    },
+                    {
+                        "src": "/origin/rpm",
+                        "dest": "/origin/rpms",
+                        "exclude_paths": ["/iso/"]
+                    },
                 ],
                 "releasever_alias": [
                     {
                         "dest": "/content/dist/rhel8/8.5",
                         "src": "/content/dist/rhel8/8",
+                        "exclude_paths": ["/files/", "/images/", "/iso/"]
                     },
+
                 ],
                 "rhui_alias": [
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
+                        "exclude_paths": ["/files/", "/images/", "/iso/"]
                     },
                 ],
             }

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -320,8 +320,9 @@ class Alias(BaseModel):
         ..., description="Target of the alias, relative to CDN root."
     )
     exclude_paths: list[str] | None = Field(
-        [], description="Paths for which alias will not be resolved, "
-                        "treated as an unanchored regex."
+        [],
+        description="Paths for which alias will not be resolved, "
+        "treated as an unanchored regex.",
     )
 
 

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -319,6 +319,10 @@ class Alias(BaseModel):
     dest: str = Field(
         ..., description="Target of the alias, relative to CDN root."
     )
+    exclude_paths: list[str] | None = Field(
+        [], description="Paths for which alias will not be resolved, "
+                        "treated as an unanchored regex."
+    )
 
 
 class YumVariable(Enum):

--- a/exodus_gw/worker/cache.py
+++ b/exodus_gw/worker/cache.py
@@ -36,7 +36,7 @@ class Flusher:
         paths: list[str],
         settings: Settings,
         env: str,
-        aliases: list[tuple[str, str]],
+        aliases: list[tuple[str, str, list[str]]],
     ):
         self.paths = [p for p in paths if not exclude_path(p)]
         self.settings = settings

--- a/exodus_gw/worker/deploy.py
+++ b/exodus_gw/worker/deploy.py
@@ -153,8 +153,12 @@ def deploy_config(
                 # If any original exclusion matches the uri, the uri wouldn't
                 # have been treated as an alias, thus cache flushing would be
                 # unnecessary.
-                if any([re.search(exclusion, published_path.web_uri)
-                        for exclusion in original_exclusions.get(src, [])]):
+                if any(
+                    [
+                        re.search(exclusion, published_path.web_uri)
+                        for exclusion in original_exclusions.get(src, [])
+                    ]
+                ):
                     continue
                 LOG.info(
                     "Updated alias %s will flush cache for %s",

--- a/exodus_gw/worker/deploy.py
+++ b/exodus_gw/worker/deploy.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any
 
 import dramatiq
@@ -93,7 +94,8 @@ def deploy_config(
     db = Session(bind=db_engine(settings))
     ddb = DynamoDB(env, settings, from_date)
 
-    original_aliases = {src: dest for (src, dest) in ddb.aliases_for_flush}
+    original_aliases = {src: dest for (src, dest, _) in ddb.aliases_for_flush}
+    original_exclusions = {src: exc for (src, _, exc) in ddb.aliases_for_flush}
 
     message = CurrentMessage.get_current_message()
     assert message
@@ -142,12 +144,18 @@ def deploy_config(
     # URLs depending on what changed in the config.
     flush_paths: set[str] = set()
 
-    for src, updated_dest in ddb.aliases_for_flush:
+    for src, updated_dest, _ in ddb.aliases_for_flush:
         if original_aliases.get(src) != updated_dest:
             for published_path in db.query(models.PublishedPath).filter(
                 models.PublishedPath.env == env,
                 models.PublishedPath.web_uri.like(f"{src}/%"),
             ):
+                # If any original exclusion matches the uri, the uri wouldn't
+                # have been treated as an alias, thus cache flushing would be
+                # unnecessary.
+                if any([re.search(exclusion, published_path.web_uri)
+                        for exclusion in original_exclusions.get(src, [])]):
+                    continue
                 LOG.info(
                     "Updated alias %s will flush cache for %s",
                     src,

--- a/tests/aws/test_uri_alias.py
+++ b/tests/aws/test_uri_alias.py
@@ -145,34 +145,45 @@ def test_uri_alias_limit(caplog: pytest.LogCaptureFixture):
         (
             "/content/dist/rhel9/9/x86_64/baseos/iso/PULP_MANIFEST",
             [
-                ("/content/dist/rhel9/9", "/content/dist/rhel9/9.5", ["/iso/"]),
+                (
+                    "/content/dist/rhel9/9",
+                    "/content/dist/rhel9/9.5",
+                    ["/iso/"],
+                ),
             ],
             # just returns the original
             ["/content/dist/rhel9/9/x86_64/baseos/iso/PULP_MANIFEST"],
             "Aliasing for /content/dist/rhel9/9/x86_64/baseos/iso/PULP_MANIFEST "
-            "was not applied as it matches one of the following exclusion paths: /iso/."
+            "was not applied as it matches one of the following exclusion paths: /iso/.",
         ),
         (
             "/some/path/with/file/in/it",
             [
-                ("/some/path", "/another/different/path", ["/none/", "/here/"]),
-                ("/another/different/path", "/this/wont/alias", ["/file/"])
+                (
+                    "/some/path",
+                    "/another/different/path",
+                    ["/none/", "/here/"],
+                ),
+                ("/another/different/path", "/this/wont/alias", ["/file/"]),
             ],
-            ["/another/different/path/with/file/in/it",
-             "/some/path/with/file/in/it"],
+            [
+                "/another/different/path/with/file/in/it",
+                "/some/path/with/file/in/it",
+            ],
             "Aliasing for /another/different/path/with/file/in/it was not "
-            "applied as it matches one of the following exclusion paths: /file/."
+            "applied as it matches one of the following exclusion paths: /file/.",
         ),
         (
             "/my/base/content/path/cool_iso_tool.rpm",
             [
                 ("/my/base", "/your/own", ["/iso/"]),
             ],
-            ["/your/own/content/path/cool_iso_tool.rpm",
-             "/my/base/content/path/cool_iso_tool.rpm"],
+            [
+                "/your/own/content/path/cool_iso_tool.rpm",
+                "/my/base/content/path/cool_iso_tool.rpm",
+            ],
             "Resolved alias:\\n\\tsrc: /my/base/content/path/cool_iso_tool.rpm"
-            "\\n\\tdest: /your/own/content/path/cool_iso_tool.rpm"
-
+            "\\n\\tdest: /your/own/content/path/cool_iso_tool.rpm",
         ),
         (
             "/content/dist/rhel9/9.5/x86_64/baseos/iso/PULP_MANIFEST",
@@ -182,21 +193,28 @@ def test_uri_alias_limit(caplog: pytest.LogCaptureFixture):
             ["/content/dist/rhel9/9.5/x86_64/baseos/iso/PULP_MANIFEST"],
             "Aliasing for /content/dist/rhel9/9.5/x86_64/baseos/iso/PULP_MANIFEST "
             "was not applied as it matches one of the following exclusion "
-            "paths: /rhel[89]/."
+            "paths: /rhel[89]/.",
         ),
         (
             "/content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
             [
                 ("/content/dist", "/alias/path", ["/rhel[89]/"]),
             ],
-            ["/alias/path/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
-             "/content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",],
+            [
+                "/alias/path/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
+                "/content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
+            ],
             "Resolved alias:\\n\\tsrc: /content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST"
-            "\\n\\tdest: /alias/path/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST"
+            "\\n\\tdest: /alias/path/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
         ),
     ],
-
-    ids=["basic", "transitive", "filename",  "pattern_include", "pattern_exclude"],
+    ids=[
+        "basic",
+        "transitive",
+        "filename",
+        "pattern_include",
+        "pattern_exclude",
+    ],
 )
 def test_uri_alias_exclusions(input, aliases, output, log_message, caplog):
     caplog.set_level(DEBUG, logger="exodus-gw")

--- a/tests/aws/test_uri_alias.py
+++ b/tests/aws/test_uri_alias.py
@@ -11,8 +11,8 @@ from exodus_gw.aws.util import uri_alias
         (
             "/content/origin/rpms/path/to/file.iso",
             [
-                ("/content/origin", "/origin"),
-                ("/origin/rpm", "/origin/rpms"),
+                ("/content/origin", "/origin", []),
+                ("/origin/rpm", "/origin/rpms", []),
             ],
             [
                 "/origin/rpms/path/to/file.iso",
@@ -22,7 +22,7 @@ from exodus_gw.aws.util import uri_alias
         (
             "/content/dist/rhel8/8/path/to/file.rpm",
             [
-                ("/content/dist/rhel8/8", "/content/dist/rhel8/8.5"),
+                ("/content/dist/rhel8/8", "/content/dist/rhel8/8.5", []),
             ],
             [
                 "/content/dist/rhel8/8.5/path/to/file.rpm",
@@ -50,8 +50,8 @@ def test_uri_alias_multi_level_write():
     aliases = [
         # The data here is made up as there is not currently any identified
         # realistic scenario having multi-level aliases during write.
-        ("/content/testproduct/1", "/content/testproduct/1.1.0"),
-        ("/content/other", "/content/testproduct"),
+        ("/content/testproduct/1", "/content/testproduct/1.1.0", []),
+        ("/content/other", "/content/testproduct", []),
     ]
 
     out = uri_alias(uri, aliases)
@@ -74,10 +74,10 @@ def test_uri_alias_multi_level_flush():
     aliases = [
         # The caller is providing aliases in both src => dest and
         # dest => src directions, as in the "cache flush" case.
-        ("/content/dist/rhel8/8", "/content/dist/rhel8/8.8"),
-        ("/content/dist/rhel8/8.8", "/content/dist/rhel8/8"),
-        ("/content/dist/rhel8/rhui", "/content/dist/rhel8"),
-        ("/content/dist/rhel8", "/content/dist/rhel8/rhui"),
+        ("/content/dist/rhel8/8", "/content/dist/rhel8/8.8", []),
+        ("/content/dist/rhel8/8.8", "/content/dist/rhel8/8", []),
+        ("/content/dist/rhel8/rhui", "/content/dist/rhel8", []),
+        ("/content/dist/rhel8", "/content/dist/rhel8/rhui", []),
     ]
 
     out = uri_alias(uri, aliases)
@@ -108,15 +108,15 @@ def test_uri_alias_limit(caplog: pytest.LogCaptureFixture):
     # actually used on production.
 
     uri = "/path/a/repo"
-    aliases = [
-        ("/path/a", "/path/b"),
-        ("/path/b", "/path/c"),
-        ("/path/c", "/path/d"),
-        ("/path/d", "/path/e"),
-        ("/path/e", "/path/f"),
-        ("/path/f", "/path/g"),
-        ("/path/g", "/path/h"),
-        ("/path/h", "/path/i"),
+    aliases: list[tuple[str, str, list[str]]] = [
+        ("/path/a", "/path/b", []),
+        ("/path/b", "/path/c", []),
+        ("/path/c", "/path/d", []),
+        ("/path/d", "/path/e", []),
+        ("/path/e", "/path/f", []),
+        ("/path/f", "/path/g", []),
+        ("/path/g", "/path/h", []),
+        ("/path/h", "/path/i", []),
     ]
 
     out = uri_alias(uri, aliases)
@@ -136,4 +136,73 @@ def test_uri_alias_limit(caplog: pytest.LogCaptureFixture):
     # It should have warned us about this.
     assert (
         "Aliases too deeply nested, bailing out at /path/f/repo" in caplog.text
+    )
+
+
+@pytest.mark.parametrize(
+    "input,aliases,output,log_message",
+    [
+        (
+            "/content/dist/rhel9/9/x86_64/baseos/iso/PULP_MANIFEST",
+            [
+                ("/content/dist/rhel9/9", "/content/dist/rhel9/9.5", ["/iso/"]),
+            ],
+            # just returns the original
+            ["/content/dist/rhel9/9/x86_64/baseos/iso/PULP_MANIFEST"],
+            "Aliasing for /content/dist/rhel9/9/x86_64/baseos/iso/PULP_MANIFEST "
+            "was not applied as it matches one of the following exclusion paths: /iso/."
+        ),
+        (
+            "/some/path/with/file/in/it",
+            [
+                ("/some/path", "/another/different/path", ["/none/", "/here/"]),
+                ("/another/different/path", "/this/wont/alias", ["/file/"])
+            ],
+            ["/another/different/path/with/file/in/it",
+             "/some/path/with/file/in/it"],
+            "Aliasing for /another/different/path/with/file/in/it was not "
+            "applied as it matches one of the following exclusion paths: /file/."
+        ),
+        (
+            "/my/base/content/path/cool_iso_tool.rpm",
+            [
+                ("/my/base", "/your/own", ["/iso/"]),
+            ],
+            ["/your/own/content/path/cool_iso_tool.rpm",
+             "/my/base/content/path/cool_iso_tool.rpm"],
+            "Resolved alias:\\n\\tsrc: /my/base/content/path/cool_iso_tool.rpm"
+            "\\n\\tdest: /your/own/content/path/cool_iso_tool.rpm"
+
+        ),
+        (
+            "/content/dist/rhel9/9.5/x86_64/baseos/iso/PULP_MANIFEST",
+            [
+                ("/content/dist", "/alias/path", ["/rhel[89]/"]),
+            ],
+            ["/content/dist/rhel9/9.5/x86_64/baseos/iso/PULP_MANIFEST"],
+            "Aliasing for /content/dist/rhel9/9.5/x86_64/baseos/iso/PULP_MANIFEST "
+            "was not applied as it matches one of the following exclusion "
+            "paths: /rhel[89]/."
+        ),
+        (
+            "/content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
+            [
+                ("/content/dist", "/alias/path", ["/rhel[89]/"]),
+            ],
+            ["/alias/path/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",
+             "/content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST",],
+            "Resolved alias:\\n\\tsrc: /content/dist/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST"
+            "\\n\\tdest: /alias/path/rhel7/7.5/x86_64/baseos/iso/PULP_MANIFEST"
+        ),
+    ],
+
+    ids=["basic", "transitive", "filename",  "pattern_include", "pattern_exclude"],
+)
+def test_uri_alias_exclusions(input, aliases, output, log_message, caplog):
+    caplog.set_level(DEBUG, logger="exodus-gw")
+    assert uri_alias(input, aliases) == output
+    assert (
+        f'"message": "{log_message}", '
+        '"event": "publish", '
+        '"success": true' in caplog.text
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from exodus_gw.dramatiq import Broker
 
 from .async_utils import BlockDetector
 
+DEFAULT_EXCLUDE_PATHS = ["/files/", "/images/", "/iso/"]
+
 
 async def fake_aexit_instancemethod(self, exc_type, exc_val, exc_tb):
     pass
@@ -267,24 +269,39 @@ def fake_config():
             },
         },
         "origin_alias": [
-            {"src": "/content/origin", "dest": "/origin"},
-            {"src": "/origin/rpm", "dest": "/origin/rpms"},
+            {
+                "src": "/content/origin",
+                "dest": "/origin",
+                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
+            },
+            {
+                "src": "/origin/rpm",
+                "dest": "/origin/rpms",
+                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
+            },
         ],
         "releasever_alias": [
             {
                 "src": "/content/dist/rhel8/8",
                 "dest": "/content/dist/rhel8/8.5",
+                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
             {
                 "src": "/content/testproduct/1",
                 "dest": "/content/testproduct/1.1.0",
+                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
         ],
         "rhui_alias": [
-            {"src": "/content/dist/rhel8/rhui", "dest": "/content/dist/rhel8"},
+            {
+                "src": "/content/dist/rhel8/rhui",
+                "dest": "/content/dist/rhel8",
+                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
+            },
             {
                 "src": "/content/testproduct/rhui",
                 "dest": "/content/testproduct",
+                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
         ],
     }

--- a/tests/routers/test_config.py
+++ b/tests/routers/test_config.py
@@ -46,7 +46,11 @@ def test_deploy_config_typical(fake_config, auth_header, endpoint):
         {"listing": {"/origin/rhel/server": {"values": ["8"], "var": "nope"}}},
         {
             "rhui_alias": [
-                {"dest": "/../rhel/rhui/server", "src": "/../rhel/rhui/server"}
+                {
+                    "dest": "/../rhel/rhui/server",
+                    "src": "/../rhel/rhui/server",
+                    "exclude_paths": ["/this/", "/is/", "/fine/"],
+                }
             ]
         },
         {"no_dont": 123},

--- a/tests/worker/test_cdn_cache.py
+++ b/tests/worker/test_cdn_cache.py
@@ -209,10 +209,20 @@ excludes =
                         {
                             "origin_alias": [],
                             "releasever_alias": [
-                                {"src": "/path/one", "dest": "/path/one-dest"},
+                                {
+                                    "src": "/path/one",
+                                    "dest": "/path/one-dest",
+                                    "exclude_paths": ["/files/", "/images/",
+                                                      "/iso/"],
+                                },
                             ],
                             "rhui_alias": [
-                                {"src": "/path/rhui/two", "dest": "/path/two"},
+                                {
+                                    "src": "/path/rhui/two",
+                                    "dest": "/path/two",
+                                    "exclude_paths": ["/files/", "/images/",
+                                                      "/iso/"],
+                                    },
                             ],
                         }
                     )

--- a/tests/worker/test_cdn_cache.py
+++ b/tests/worker/test_cdn_cache.py
@@ -212,17 +212,23 @@ excludes =
                                 {
                                     "src": "/path/one",
                                     "dest": "/path/one-dest",
-                                    "exclude_paths": ["/files/", "/images/",
-                                                      "/iso/"],
+                                    "exclude_paths": [
+                                        "/files/",
+                                        "/images/",
+                                        "/iso/",
+                                    ],
                                 },
                             ],
                             "rhui_alias": [
                                 {
                                     "src": "/path/rhui/two",
                                     "dest": "/path/two",
-                                    "exclude_paths": ["/files/", "/images/",
-                                                      "/iso/"],
-                                    },
+                                    "exclude_paths": [
+                                        "/files/",
+                                        "/images/",
+                                        "/iso/",
+                                    ],
+                                },
                             ],
                         }
                     )

--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -166,7 +166,7 @@ def test_deploy_config_with_flush(
         {
             "dest": "/content/testproduct/1.2.0",
             "src": "/content/testproduct/1",
-            "exclude_paths": ["/newExclusion/"]
+            "exclude_paths": ["/newExclusion/"],
         },
     ]
     worker.deploy_config(updated_config, "test", NOW_UTC)
@@ -222,7 +222,7 @@ def test_deploy_config_with_flush(
         "/content/dist/rhel/server/listing",
         "/content/testproduct/1/file1",
         "/content/testproduct/1/file2",
-        "/content/testproduct/1/newExclusion/file5"
+        "/content/testproduct/1/newExclusion/file5",
     ]
 
     # And actor call should have been delayed by this long.

--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -138,6 +138,26 @@ def test_deploy_config_with_flush(
         )
     )
 
+    # Exclusion tests. This Path should not be flushed as it contains part of
+    # the original alias exclusions.
+    db.add(
+        PublishedPath(
+            env="test",
+            web_uri="/content/testproduct/1/iso/file4",
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+
+    # This path will be flushed as it was not part of the original alias
+    # exclusions.
+    db.add(
+        PublishedPath(
+            env="test",
+            web_uri="/content/testproduct/1/newExclusion/file5",
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+
     db.commit()
 
     # We're updating the alias in the config.
@@ -146,6 +166,7 @@ def test_deploy_config_with_flush(
         {
             "dest": "/content/testproduct/1.2.0",
             "src": "/content/testproduct/1",
+            "exclude_paths": ["/newExclusion/"]
         },
     ]
     worker.deploy_config(updated_config, "test", NOW_UTC)
@@ -201,6 +222,7 @@ def test_deploy_config_with_flush(
         "/content/dist/rhel/server/listing",
         "/content/testproduct/1/file1",
         "/content/testproduct/1/file2",
+        "/content/testproduct/1/newExclusion/file5"
     ]
 
     # And actor call should have been delayed by this long.


### PR DESCRIPTION
Certain paths on our NetStorage fs have no symlinks/aliases, and teams/tools that make use of these paths expect similar behaviour from exodus.
This change introduces "exclude_paths" to exclude alias generation for certain paths, so we can replicate NetStorage behaviour.
