### PR TITLE
Upgrade python version used by pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: 24.8.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.11
 -   repo: https://github.com/pycqa/isort/
     rev: 5.13.2
     hooks:
     - id: isort
-      language_version: python3.8
+      language_version: python3.11


### PR DESCRIPTION
Black requires Python 3.9+ to run. The installation of the black pre-commit environment currently fails with:

`RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.8'`

This commit upgrades the target Python verison used by the pre-commit hooks to 3.11, the minimum Python version required by exodus-gw.