### PR TITLE
Mark all kickstart non-RPM content as phase2 [RHELDST-28021]

### DIFF
--- a/exodus_gw/settings.py
+++ b/exodus_gw/settings.py
@@ -377,6 +377,24 @@ class Settings(BaseSettings):
     ]
     """List of file names that should be saved for last when publishing."""
 
+    phase2_patterns: list[re.Pattern[str]] = [
+        # kickstart repos; note the logic here matches
+        # the manual workaround RHELDST-27642
+        re.compile(r"/kickstart/.*(?<!\.rpm)$"),
+    ]
+    """List of patterns which, if any have matched, force a path to
+    be handled during phase 2 of commit.
+
+    These patterns are intended for use with repositories not cleanly
+    separated between mutable entry points and immutable content.
+
+    For example, in-place updates to kickstart repositories may not
+    only modify entry points such as extra_files.json but also
+    arbitrary files referenced by that entry point, all of which should
+    be processed during phase 2 of commit in order for updates to
+    appear atomic.
+    """
+
     autoindex_filename: str = ".__exodus_autoindex"
     """Filename for indexes automatically generated during publish.
 


### PR DESCRIPTION
Kickstart repos don't adhere to the "mutable entry point, immutable
everything else" design of other content types, such as yum and
file repos. For example, files such as "/EULA", "/images/install.img"
may receive in-place updates.

As such, the usual categorization between phase1 and phase2 content
based on entry points does not fit these repos correctly.

From the point of view of exodus-gw, the set of files receiving
in-place updates is arbitrary, so we'd better treat them *all* as phase
2 content and try to update them together. RPM files are the only
exception, as we still expect that an RPM published to the same
path is always the same thing.

The effects of categorizing kickstart files as phase2 content include:

- on publish, CDN cache will now be flushed for all non-RPM kickstart
  paths (rather than only the entry points).

- on publish, non-RPM kickstart paths will be recorded into
  PublishedPath table, which allows them to trigger cache flush again
  when releasever_alias are updated in config. (This is the primary
  motivation for the change, as this important cache flush currently
  must be done manually.)

- in-place updates to the repos are now more likely to appear as atomic
  from the customer's point of view.

- kickstart publishes may be somewhat slower, as it is necessary to
  delay more of the publishing work until the user requests the final
  commit.
