### PR TITLE
dev-env: add missing role for config getter endpoint

### DIFF
--- a/scripts/systemd/exodus-gw-sidecar.service
+++ b/scripts/systemd/exodus-gw-sidecar.service
@@ -41,6 +41,9 @@ com.redhat.api.platform:\n\
    test-config-deployer:\n\
     users:\n\
      byInternalUsername: [${USER}]\n\
+   test-config-consumer:\n\
+    users:\n\
+     byInternalUsername: [${USER}]\n\
    test-cdn-consumer:\n\
     users:\n\
      byInternalUsername: [${USER}]\n\


### PR DESCRIPTION
The `{env}-config-consumer` role was introduced along with the "GET /{env}/config" endpoint. Make sure the role is granted to the test user in the development environment so that it can be accessed there.