### PR TITLE
Flush transitive aliases during deployment [RHELDST-28321]

### DIFF
--- a/exodus_gw/models/path.py
+++ b/exodus_gw/models/path.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 
-
+# pylint: disable=unsubscriptable-object
 class PublishedPath(Base):
     """Represents a path updated on the CDN at some point.
 

--- a/exodus_gw/models/path.py
+++ b/exodus_gw/models/path.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 
+
 # pylint: disable=unsubscriptable-object
 class PublishedPath(Base):
     """Represents a path updated on the CDN at some point.

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -21,7 +21,7 @@ from exodus_gw.schemas import ItemBase
 
 from .base import Base
 
-
+# pylint: disable=unsubscriptable-object
 class Publish(Base):
     __tablename__ = "publishes"
 

--- a/exodus_gw/models/publish.py
+++ b/exodus_gw/models/publish.py
@@ -21,6 +21,7 @@ from exodus_gw.schemas import ItemBase
 
 from .base import Base
 
+
 # pylint: disable=unsubscriptable-object
 class Publish(Base):
     __tablename__ = "publishes"

--- a/exodus_gw/worker/deploy.py
+++ b/exodus_gw/worker/deploy.py
@@ -150,9 +150,14 @@ def deploy_config(
         if original_aliases.get(src) != updated_dest:
             updated_prefixes.add(src)
 
-    aliases_to_expand = [alias for alias in ddb.aliases_for_flush
-                         if alias[0] in original_aliases.keys()]
-    updated_prefixes.update(uris_with_aliases(updated_prefixes, aliases_to_expand))
+    aliases_to_expand = [
+        alias
+        for alias in ddb.aliases_for_flush
+        if alias[0] in original_aliases.keys()
+    ]
+    updated_prefixes.update(
+        uris_with_aliases(updated_prefixes, aliases_to_expand)
+    )
 
     for src in updated_prefixes:
         for published_path in db.query(models.PublishedPath).filter(

--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -158,6 +158,21 @@ def test_deploy_config_with_flush(
         )
     )
 
+    # These paths should be flushed after expanding the updated aliases.
+    db.add(
+        PublishedPath(
+            env="test",
+            web_uri="/content/testproduct/rhui/1/file1",
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+    db.add(
+        PublishedPath(
+            env="test",
+            web_uri="/content/testproduct/rhui/1/file2",
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
     db.commit()
 
     # We're updating the alias in the config.
@@ -223,6 +238,8 @@ def test_deploy_config_with_flush(
         "/content/testproduct/1/file1",
         "/content/testproduct/1/file2",
         "/content/testproduct/1/newExclusion/file5",
+        "/content/testproduct/rhui/1/file1",
+        "/content/testproduct/rhui/1/file2",
     ]
 
     # And actor call should have been delayed by this long.


### PR DESCRIPTION
We saw some repo instability after a recent GA. This was due to only a portion of affected URLs being flushed. The current deployment cache flush only gets URLs based on directly updated aliases. This didn't take into consideration URLs that require several aliases to be applied.