### PR TITLE
 Fixup: remove mentions of /images/  [RHELDST-26015]

### DIFF
--- a/exodus_gw/aws/util.py
+++ b/exodus_gw/aws/util.py
@@ -222,7 +222,7 @@ def uri_alias_recurse(
     for src, dest, exclude_paths in aliases:
         if uri.startswith(src + "/") or uri == src:
             # Used to replicate old NetStorage-compatible behaviour. This will
-            # typically match non-rpm paths, such as /images/ or /isos/
+            # typically match non-rpm paths, such as /isos/
             if any([re.search(exclusion, uri) for exclusion in exclude_paths]):
                 LOG.debug(
                     "Aliasing for %s was not applied as it matches one "

--- a/exodus_gw/routers/config.py
+++ b/exodus_gw/routers/config.py
@@ -155,14 +155,14 @@ def config_post(
                     {
                         "dest": "/content/dist/rhel8/8.5",
                         "src": "/content/dist/rhel8/8",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"],
+                        "exclude_paths": ["/files/", "/iso/"],
                     },
                 ],
                 "rhui_alias": [
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"],
+                        "exclude_paths": ["/files/", "/iso/"],
                     },
                 ],
             }

--- a/exodus_gw/routers/deploy.py
+++ b/exodus_gw/routers/deploy.py
@@ -71,14 +71,14 @@ def deploy_config(
                     {
                         "dest": "/content/dist/rhel8/8.5",
                         "src": "/content/dist/rhel8/8",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"],
+                        "exclude_paths": ["/files/", "/iso/"],
                     },
                 ],
                 "rhui_alias": [
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
-                        "exclude_paths": ["/files/", "/images/", "/iso/"],
+                        "exclude_paths": ["/files/", "/iso/"],
                     },
                 ],
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from exodus_gw.dramatiq import Broker
 
 from .async_utils import BlockDetector
 
-DEFAULT_EXCLUDE_PATHS = ["/files/", "/images/", "/iso/"]
+DEFAULT_EXCLUDE_PATHS = ["/files/", "/iso/"]
 
 
 async def fake_aexit_instancemethod(self, exc_type, exc_val, exc_tb):

--- a/tests/worker/test_cdn_cache.py
+++ b/tests/worker/test_cdn_cache.py
@@ -214,7 +214,6 @@ excludes =
                                     "dest": "/path/one-dest",
                                     "exclude_paths": [
                                         "/files/",
-                                        "/images/",
                                         "/iso/",
                                     ],
                                 },
@@ -225,7 +224,6 @@ excludes =
                                     "dest": "/path/two",
                                     "exclude_paths": [
                                         "/files/",
-                                        "/images/",
                                         "/iso/",
                                     ],
                                 },


### PR DESCRIPTION
It was noted that including the /images/ path can cause issues with kickstart repos as the path can occur within repos. This complication makes the path less appropriate for blanket exclusions. This change removes mentions of /images/ from tests to prevent later confusion.