### PR TITLE
unlock pydantic version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 fastapi
 starlette>=0.21.0
-pydantic==2.10.5
+pydantic
 pydantic-settings
 aioboto3
 defusedxml


### PR DESCRIPTION
The version for pydantic was locked to resolve dependency conflict caused by pip-compile. Now that the conflict is resolved, we can unlock the version.