### PR TITLE
Get config endpoint returns valid empty config [RHELDST-28276]

### DIFF
--- a/exodus_gw/aws/dynamodb.py
+++ b/exodus_gw/aws/dynamodb.py
@@ -169,10 +169,16 @@ class DynamoDB:
 
     def query_definitions(self) -> dict[str, Any]:
         """Query the definitions in the config_table. If definitions are found, return them. Otherwise,
-        return an empty dictionary."""
+        return a valid empty configuration."""
 
-        # Return an empty dict if a query result is not found
-        out: dict[str, Any] = {}
+        # If a query result is not found, return a reasonable default object representing a valid
+        # empty configuration.
+        out: dict[str, Any] = {
+            "listing": {},
+            "origin_alias": [],
+            "releasever_alias": [],
+            "rhui_alias": [],
+        }
 
         LOG.info(
             "Loading exodus-config as at %s.",

--- a/tests/routers/test_config.py
+++ b/tests/routers/test_config.py
@@ -16,6 +16,23 @@ def test_config_get(auth_header, fake_config, mock_boto3_client):
     assert r.json() == fake_config
 
 
+def test_config_get_empty_config(auth_header, mock_boto3_client_empty_config):
+    with TestClient(app) as client:
+        r = client.get(
+            "/test/config",
+            headers=auth_header(roles=["test-config-consumer"]),
+        )
+
+    # It should have succeeded and returned the default empty config
+    assert r.status_code == 200
+    assert r.json() == {
+        "listing": {},
+        "origin_alias": [],
+        "releasever_alias": [],
+        "rhui_alias": [],
+    }
+
+
 @pytest.mark.parametrize("endpoint", ["config", "deploy-config"])
 def test_deploy_config_typical(fake_config, auth_header, endpoint):
     with TestClient(app) as client:


### PR DESCRIPTION
Previously, exodus-gw would fail with a 500 error when attempting to use the "get config" endpoint (i.e., GET /{env}/config) against an environment with an empty config table.

Now, when attempting to use the "get config" endpoint against an environment with an empty config table, exodus-gw returns a default object representing a valid empty config.

```
$ curl -s --cert ~/certs/$USER.crt --key ~/certs/$USER.key \
     https://localhost:8010/test/config | jq
{
  "listing": {
    "": {
      "var": "releasever",
      "values": [
        ""
      ]
    }
  },
  "origin_alias": [
    {
      "src": "",
      "dest": "",
      "exclude_paths": []
    }
  ],
  "releasever_alias": [
    {
      "src": "",
      "dest": "",
      "exclude_paths": []
    }
  ],
  "rhui_alias": [
    {
      "src": "",
      "dest": "",
      "exclude_paths": []
    }
  ]
}
```