### PR TITLE
Exclude empty exclude_paths from config [RHELDST-29250]

### DIFF
--- a/exodus_gw/routers/config.py
+++ b/exodus_gw/routers/config.py
@@ -143,12 +143,10 @@ def config_post(
                     {
                         "src": "/content/origin",
                         "dest": "/origin",
-                        "exclude_paths": [],
                     },
                     {
                         "src": "/origin/rpm",
                         "dest": "/origin/rpms",
-                        "exclude_paths": ["/iso/"],
                     },
                 ],
                 "releasever_alias": [
@@ -162,7 +160,6 @@ def config_post(
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
-                        "exclude_paths": ["/files/", "/iso/"],
                     },
                 ],
             }
@@ -216,6 +213,7 @@ def config_post(
 @router.get(
     "/{env}/config",
     response_model=schemas.Config,
+    response_model_exclude_none=True,
     summary="Get CDN configuration",
     status_code=200,
     responses={
@@ -234,6 +232,7 @@ def config_post(
                 {
                     "dest": "/content/dist/rhel-alt/server/7/7.9",
                     "src": "/content/dist/rhel-alt/server/7/7Server",
+                    "exclude_paths": ["/files/", "/iso/"],
                 },
             ],
             "rhui_alias": [

--- a/exodus_gw/routers/deploy.py
+++ b/exodus_gw/routers/deploy.py
@@ -59,12 +59,10 @@ def deploy_config(
                     {
                         "src": "/content/origin",
                         "dest": "/origin",
-                        "exclude_paths": [],
                     },
                     {
                         "src": "/origin/rpm",
                         "dest": "/origin/rpms",
-                        "exclude_paths": ["/iso/"],
                     },
                 ],
                 "releasever_alias": [
@@ -78,7 +76,6 @@ def deploy_config(
                     {
                         "dest": "/content/dist/rhel8",
                         "src": "/content/dist/rhel8/rhui",
-                        "exclude_paths": ["/files/", "/iso/"],
                     },
                 ],
             }

--- a/exodus_gw/schemas.py
+++ b/exodus_gw/schemas.py
@@ -320,7 +320,7 @@ class Alias(BaseModel):
         ..., description="Target of the alias, relative to CDN root."
     )
     exclude_paths: list[str] | None = Field(
-        [],
+        None,
         description="Paths for which alias will not be resolved, "
         "treated as an unanchored regex.",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,12 +309,10 @@ def fake_config():
             {
                 "src": "/content/origin",
                 "dest": "/origin",
-                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
             {
                 "src": "/origin/rpm",
                 "dest": "/origin/rpms",
-                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
         ],
         "releasever_alias": [
@@ -338,12 +336,10 @@ def fake_config():
             {
                 "src": "/content/dist/rhel8/rhui",
                 "dest": "/content/dist/rhel8",
-                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
             {
                 "src": "/content/testproduct/rhui",
                 "dest": "/content/testproduct",
-                "exclude_paths": DEFAULT_EXCLUDE_PATHS,
             },
         ],
     }


### PR DESCRIPTION
Currently, when we attempt to use exodus-gw's "get config" endpoint to fetch the current config stored in DynamoDB, exodus-gw sanitizes the "get config" endpoint's response by including an "exclude_paths" property on all aliases, even when the property is empty.

```
{
  [...]
  "origin_alias": [
    {
      "src": "/content/origin",
      "dest": "/origin",
      "exclude_paths": []
    },
    {
      "src": "/origin/rpm",
      "dest": "/origin/rpms",
      "exclude_paths": []
    }
  ],
  [...]
  "rhui_alias": [
  [...]
    {
      "src": "/content/beta/rhel/rhui",
      "dest": "/content/beta/rhel",
      "exclude_paths": []
    },
  [...]
}
```

The config POSTed to exodus-gw is generated by exodus-config; the generated config does not enforce adding an exclude_paths property on all aliases; exodus-config only appends an exclude_paths property onto an alias when the exclude_paths property is populated/non-empty.

So, when generating a diff between the new config (generated by exodus-config) and the current config fetched from exodus-gw, the diff will always suggest that the new config is attempting to remove the empty "exclude_paths" property from all aliases:

```
--- config from exodus-gw GET config endpoint
+++ config created by exodus-config
@@ -3861,277 +3861,362 @@
     var: releasever
 origin_alias:
 - dest: /origin
-  exclude_paths: []
   src: /content/origin
 - dest: /origin/rpms
-  exclude_paths: []
   src: /origin/rpm
[...]
```

This diff is misleading; one may think that the config stored in DynamoDB contains an exclude_paths property on each alias, but the config stored in DynamoDB is identical to the config produced by exodus-config (meaning that the aliases stored in the config in DynamoDB do not contain any empty exclude_paths properties):

```
{
  "origin_alias": [
    {
      "src": "/content/origin",
      "dest": "/origin",
    },
    {
      "src": "/origin/rpm",
      "dest": "/origin/rpms",
    }
  ],
  [...]
  "releasever_alias": [
  [...]
  {
    'src': '/content/dist/rhel8/8',
    'dest': '/content/dist/rhel8/8.10',
    'exclude_paths': [
      '/files/',
      '/iso/'
    ],
  },
  [...]
}
```

The "exclude_paths" property was designed to be an optional property added on to aliases. It is not expected by exodus-lambda, so there is no reason as to why the "get config" endpoint's responses should be sanitized such that an empty "exclude_paths" property is always appended to all aliases without a populated "exclude_paths" property.

This commit adjusts the response from the "get config" endpoint such that empty "exclude_paths" properties are excluded from responses.