### PR TITLE
Dev env updates for Alpine-based db image [RHELDST-29655]

### DIFF
--- a/scripts/systemd/exodus-gw-cert.service
+++ b/scripts/systemd/exodus-gw-cert.service
@@ -26,9 +26,11 @@ ExecStartPost=cp \
   %E/exodus-gw-dev/db-service-key.pem
 
 # private key file must be owned by the database user or root
-# set postgres(999) as owner of the private key file
+# set postgres(999) as owner of the private key file for
+# debian-based images, and postgres(70) as the owner of the
+# private key file for alpine-based images.
 ExecStartPost=/usr/bin/podman unshare \
-  chown 999:999 %E/exodus-gw-dev/db-service-key.pem
+  chown 70:70 %E/exodus-gw-dev/db-service-key.pem
 
 [Install]
 WantedBy=exodus-gw.target

--- a/scripts/systemd/exodus-gw-db.service
+++ b/scripts/systemd/exodus-gw-db.service
@@ -10,7 +10,7 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=-%E/exodus-gw-dev/.env
-Environment=EXODUS_GW_POSTGRES_IMAGE=quay.io/exodus/postgres:12
+Environment=EXODUS_GW_POSTGRES_IMAGE=quay.io/exodus/postgres:12-alpine
 Environment=EXODUS_GW_DB_SERVICE_PORT=3355
 
 Environment=PODMAN_SYSTEMD_UNIT=%n


### PR DESCRIPTION
The postgres image used in the dev env (quay.io/exodus/postgres:12) is an Alpine-based image. The image tag has been updated to clarify that the exodus-gw-db image used in the dev env is Alpine-based (quay.io/exodus/postgres:12-alpine).

Using the Alpine-based image without any changes to the dev env configuration produces the following error:

`FATAL:  private key file "/var/lib/postgresql/db-service-key.pem" must be owned by the database user or root`

Previously, we used a Debian-based postgres image wherein the standard postgres UID was 999. In Alpine-based images, the standard postgres UID is 70. The dev env configuration has been updated to reflect the UID discrepancy.