### PR TITLE
bug-fix: incorrect error expected in upload helper [RHELDST-30644]

### DIFF
--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -107,11 +107,14 @@ async def _already_uploaded(
     key: str = Path(..., description="S3 object key"),
 ):
     try:
-        response = await head(env, s3, key)
+        response = await s3.head_object(Bucket=env.bucket, Key=key)  # type: ignore
         LOG.debug(
             "s3 object already exists: %s", key, extra={"event": "upload"}
         )
-        return response
+        headers = {"ETag": response["ETag"]}
+        for k, v in response["Metadata"].items():
+            headers["x-amz-meta-%s" % k] = v
+        return Response(headers=headers)
     except ClientError as e:
         if e.response["Error"]["Code"] != "NoSuchKey":
             raise e
@@ -124,7 +127,9 @@ async def _ensure_aborted(
     key: str = Path(..., description="S3 object key"),
 ):
     try:
-        await abort_multipart_upload(env, s3, key, uploadId)
+        await s3.abort_multipart_upload(  # type: ignore
+            Bucket=env.bucket, Key=key, UploadId=uploadId
+        )
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchUpload":
             # Upload was aborted within another process
@@ -352,7 +357,7 @@ async def multipart_put(
 
     if response := await _already_uploaded(env, s3, key):
         await _ensure_aborted(uploadId, env, s3, key)
-        return Response(headers={"ETag": response.headers["etag"]})
+        return response
 
     response = await s3.upload_part(  # type: ignore
         Body=reader,

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -172,7 +172,6 @@ async def test_complete_completed_mpu(mock_aws_client, auth_header, caplog):
         "duplicate multipart upload detected, attempting to abort"
         in caplog.text
     )
-    assert "Abort 3f425a43" in caplog.text
     assert (
         "upload 3f425a43: The specified upload does not exist. The upload "
         "ID may be invalid, or the upload may have been aborted or completed."

--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -113,7 +113,6 @@ async def test_part_upload_duplicate(mock_aws_client, auth_header, caplog):
     # It should check HEAD, log message, and issue abort
     mock_aws_client.head_object.assert_called()
     assert "s3 object already exists: %s" % TEST_KEY in caplog.text
-    assert "Abort my-upload" in caplog.text
     mock_aws_client.abort_multipart_upload.assert_called()
     # It should not upload
     mock_aws_client.upload_part.assert_not_called()


### PR DESCRIPTION
In upload's `_already_uploaded` helper function, the `head` endpoint was called rather than directly calling S3's `head_object` function, but the response from `head_object` was expected rather than that of the `head` endpoint. This led to uncaught 404 codes resulting in push errors.

This commit corrects this mistake by directly using the AWS S3 sdk in helper functions `_already_uploaded` and `_ensure_aborted`, avoiding using exodus-gw endpoints within endpoints entirely, so the anticipated errors are handled appropriatly.