### PR TITLE
upload, multipart: abort if object already exists [RHELDST-30644]

### DIFF
--- a/tests/routers/upload/test_upload.py
+++ b/tests/routers/upload/test_upload.py
@@ -3,7 +3,10 @@ import pytest
 from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
 
+from exodus_gw.deps import get_environment, get_s3_client
 from exodus_gw.main import app
+from exodus_gw.routers.upload import _already_uploaded, _ensure_aborted
+from exodus_gw.settings import load_settings
 
 TEST_KEY = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
 
@@ -60,6 +63,16 @@ async def test_part_upload(mock_aws_client, mock_request_reader, auth_header):
 
     mock_request_reader.return_value = b"best bytes"
     mock_aws_client.upload_part.return_value = {"ETag": "a1b2c3"}
+    mock_aws_client.head_object.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "NoSuchKey",
+                "Message": "The specified key does not exist.",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 404},
+        },
+        "GetObject",
+    )
 
     with TestClient(app) as client:
         r = client.put(
@@ -76,6 +89,40 @@ async def test_part_upload(mock_aws_client, mock_request_reader, auth_header):
     assert r.headers["x-request-id"]
 
     # It should have an empty body
+    assert r.content == b""
+
+
+async def test_part_upload_duplicate(mock_aws_client, auth_header, caplog):
+    """Calling multipart_put when the object has already been uploaded
+    aborts the mpu and returns a valid response."""
+
+    caplog.set_level(10, "s3")
+
+    mock_aws_client.head_object.return_value = {
+        "Key": TEST_KEY,
+        "ETag": "a1b2c3",
+        "Metadata": {},
+    }
+
+    with TestClient(app) as client:
+        r = client.put(
+            "/upload/test/%s?uploadId=my-upload&partNumber=3" % TEST_KEY,
+            headers=auth_header(roles=["test-blob-uploader"]),
+        )
+
+    # It should check HEAD, log message, and issue abort
+    mock_aws_client.head_object.assert_called()
+    assert "object already uploaded: %s" % TEST_KEY in caplog.text
+    mock_aws_client.abort_multipart_upload.assert_called()
+    # It should not upload
+    mock_aws_client.upload_part.assert_not_called()
+    # It should not try to complete upload
+    mock_aws_client.complete_multipart_upload.assert_not_called()
+
+    assert r.status_code == 200
+    assert r.headers["etag"] == "a1b2c3"
+    assert r.headers["content-length"] == "0"
+    assert r.headers["x-request-id"]
     assert r.content == b""
 
 
@@ -155,3 +202,59 @@ async def test_put_error(mock_aws_client, mock_request_reader, auth_header):
         "<RequestId>aabbccdd</RequestId>"
         "</Error>"
     )
+
+
+async def test_already_uploaded_exc(mock_aws_client):
+    mock_aws_client.head_object.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "SomeUnknownError",
+                "Message": "AWS S3 implemented some new error and we somehow triggered it",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 500},
+        },
+        "GetObject",
+    )
+    env = get_environment("test")
+    settings = load_settings()
+
+    request = mock.Mock()
+    request.body = ""
+    request.app.state.settings = settings
+    request.app.state.s3_queues = {}
+
+    s3_client = await get_s3_client(
+        request=request, env=env, settings=settings
+    ).__anext__()
+
+    with pytest.raises(ClientError) as e:
+        await _already_uploaded(env, s3_client, TEST_KEY)
+        assert e.response["Error"]["Code"] == "SomeUnknownError"
+
+
+async def test_ensure_aborted_exc(mock_aws_client):
+    mock_aws_client.abort_multipart_upload.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "SomeUnknownError",
+                "Message": "AWS S3 implemented some new error and we somehow triggered it",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 500},
+        },
+        "GetObject",
+    )
+    env = get_environment("test")
+    settings = load_settings()
+
+    request = mock.Mock()
+    request.body = ""
+    request.app.state.settings = settings
+    request.app.state.s3_queues = {}
+
+    s3_client = await get_s3_client(
+        request=request, env=env, settings=settings
+    ).__anext__()
+
+    with pytest.raises(ClientError) as e:
+        await _ensure_aborted("my-upload", env, s3_client, TEST_KEY)
+        assert e.response["Error"]["Code"] == "SomeUnknownError"


### PR DESCRIPTION
To help prevent duplicate upload operations, this commit adds a check for an s3 object's existence before attempting a multipart_put or complete_multipart_upload. If the object does already exist, an abort of the multipart upload is attempted to avoid overwriting the previous object and orphaned parts are cleaned up.