### PR TITLE
Fix multipart_upload: 'Key' unavailable in head response [RHELDST-30644]

### DIFF
--- a/exodus_gw/routers/upload.py
+++ b/exodus_gw/routers/upload.py
@@ -205,7 +205,7 @@ async def multipart_upload(
             # (it was, just not here) using available data/keys
             return xml_response(
                 "CompleteMultipartUploadOutput",
-                Key=response["Key"],
+                Key=key,
                 ETag=response["ETag"],
             )
         return await complete_multipart_upload(s3, env, key, uploadId, request)

--- a/tests/routers/upload/test_manage_mpu.py
+++ b/tests/routers/upload/test_manage_mpu.py
@@ -137,7 +137,6 @@ async def test_complete_completed_mpu(mock_aws_client, auth_header, caplog):
     caplog.set_level(10, "s3")
 
     mock_aws_client.head_object.return_value = {
-        "Key": TEST_KEY,
         "ETag": "my-better-etag",
         "Metadata": {},
     }


### PR DESCRIPTION
When aborting an attempt to complete multipart upload, the returned response attempted to access "Key" from the head_object response but it isn't provided by the s3 API. Instead, it should use the local key variable.