### PR TITLE
ci: pin pip version in workflow [RHELDST-31877]

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -15,7 +15,7 @@ jobs:
          python-version: 3.12
 
      - name: Install tox
-       run: pip install tox
+       run: pip install "pip<=25.0" tox
      
      - name: pip-compile
        uses: technote-space/create-pr-action@v2


### PR DESCRIPTION
Pin pip to <=25.0 in GitHub Actions to avoid issues introduced in pip v25.1