### PR TITLE
Temporary fix for broken pip-compile [RHELDST-31877]

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -15,7 +15,7 @@ jobs:
          python-version: 3.12
 
      - name: Install tox
-       run: pip install "pip<=25.0" tox
+       run: pip install tox
      
      - name: pip-compile
        uses: technote-space/create-pr-action@v2

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ commands=pytest {posargs}
 allowlist_externals=sh
 
 [testenv:pip-compile]
-deps = pip-tools
+deps =
+    pip-tools
+    pip<=25.0  # Temporary fix for RHELDST-31877
 skip_install = true
 skipsdist = true
 commands =


### PR DESCRIPTION
* revert the previous attempt in workflow setting
* pin pip version in tox.ini