### PR TITLE
Config deployment should flush resolved paths pt. 2 [RHELDST-32942]

### DIFF
--- a/tests/worker/test_deploy.py
+++ b/tests/worker/test_deploy.py
@@ -310,8 +310,24 @@ def test_deploy_config_with_flush_only_necessary(
     db.add(
         PublishedPath(
             env="test",
+            web_uri="/content/dist/rhel8/rhui/8.5/file3",
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+
+    db.add(
+        PublishedPath(
+            env="test",
             web_uri="/content/dist/rhel8/8.6/file4",
             # Should flush /content/dist/rhel8/8/file4
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+    db.add(
+        PublishedPath(
+            env="test",
+            web_uri="/content/dist/rhel8/rhui/8.6/file4",
+            # Should flush /content/dist/rhel8/rhui/8/file4
             updated=datetime.now(tz=timezone.utc),
         )
     )
@@ -329,8 +345,24 @@ def test_deploy_config_with_flush_only_necessary(
     db.add(
         PublishedPath(
             env="test",
+            web_uri="/content/dist/rhel8/rhui/8.6/kickstart/treeinfo",
+            # Should flush /content/dist/rhel8/rhui/8/kickstart/treeinfo
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+    db.add(
+        PublishedPath(
+            env="test",
             web_uri="/content/dist/rhel8/8.6/os/repodata/repomd.xml",
             # Should flush /content/dist/rhel8/8/os/repodata/repomd.xml
+            updated=datetime.now(tz=timezone.utc),
+        )
+    )
+    db.add(
+        PublishedPath(
+            env="test",
+            web_uri="/content/dist/rhel8/rhui/8.6/os/repodata/repomd.xml",
+            # Should flush /content/dist/rhel8/rhui/8/os/repodata/repomd.xml
             updated=datetime.now(tz=timezone.utc),
         )
     )
@@ -352,7 +384,7 @@ def test_deploy_config_with_flush_only_necessary(
     updated_config["releasever_alias"] = [
         a
         for a in updated_config["releasever_alias"]
-        if a["dest"] != "/content/dist/rhel8/8.6"
+        if a["dest"] != "/content/dist/rhel8/8.5"
     ]
     updated_config["releasever_alias"].append(
         {
@@ -405,6 +437,9 @@ def test_deploy_config_with_flush_only_necessary(
         "/content/dist/rhel8/8/kickstart/treeinfo",
         "/content/dist/rhel8/8/os/repodata/repomd.xml",
         "/content/dist/rhel8/rhui/8/file2",
+        "/content/dist/rhel8/rhui/8/file4",
+        "/content/dist/rhel8/rhui/8/kickstart/treeinfo",
+        "/content/dist/rhel8/rhui/8/os/repodata/repomd.xml",
     ]
 
 


### PR DESCRIPTION
The first commit addressing flushing resolved paths post-config deployment (0076cf1) failed to account for RHUI paths.

Now, the post-deployment automatic cache flush also accounts for RHUI paths.

For example, if a config deployment updates the `/content/dist/rhel9/9` alias to point to the next minor RHEL version (and the config to be deployed also contains a RHUI alias pointing `/content/dist/rhel9/9` at `/content/dist/rhel9/rhui`, and we recently published to the following paths:

```
/content/dist/rhel9/9.7/x86_64/kickstart/treeinfo
/content/dist/rhel9/9.7/x86_64/os/Packages/a/
/content/dist/rhel9/9.7/x86_64/repodata/repomd.xml
/content/dist/rhel9/rhui/9.7/x86_64/kickstart/treeinfo
/content/dist/rhel9/rhui/9.7/x86_64/os/Packages/a/
/content/dist/rhel9/rhui/9.7/x86_64/repodata/repomd.xml
```

The following paths should be flushed during the config deployment (because the content published at these paths will have changed after the config deployment):

```
/content/dist/rhel9/9/x86_64/kickstart/treeinfo
/content/dist/rhel9/9/x86_64/os/Packages/a/
/content/dist/rhel9/9/x86_64/repodata/repomd.xml
/content/dist/rhel9/rhui/9/x86_64/kickstart/treeinfo
/content/dist/rhel9/rhui/9/x86_64/os/Packages/a/
/content/dist/rhel9/rhui/9/x86_64/repodata/repomd.xml
```

The following paths should not be flushed (because the content published at these paths will have not changed after the config deployment):

```
/content/dist/rhel9/9.7/x86_64/kickstart/treeinfo
/content/dist/rhel9/9.7/x86_64/os/Packages/a/
/content/dist/rhel9/9.7/x86_64/repodata/repomd.xml
/content/dist/rhel9/rhui/9.7/x86_64/kickstart/treeinfo
/content/dist/rhel9/rhui/9.7/x86_64/os/Packages/a/
/content/dist/rhel9/rhui/9.7/x86_64/repodata/repomd.xml
```