### PR TITLE
Onboard test coverage to Codecov [RHELDST-40398]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   run-ci:
     runs-on: ubuntu-latest
+    # Required for OIDC: https://github.com/codecov/codecov-action?tab=readme-ov-file#using-oidc
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v6
@@ -32,9 +35,15 @@ jobs:
       run: tox -e bandit
 
     - name: Run auto-tests
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: tox -e cov-ci
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        use_oidc: true
+        flags: unit-tests
+        files: coverage.xml
+        fail_ci_if_error: false
 
     - name: Run static analysis
       run: tox -e static

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ exodus-gw
 Publishing microservice for Red Hat's Content Delivery Network
 
 ![Build Status](https://github.com/release-engineering/exodus-gw/actions/workflows/ci.yml/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/release-engineering/exodus-gw/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/exodus-gw?branch=master)
+[![Coverage Status](https://app.codecov.io/gh/release-engineering/exodus-gw)](https://app.codecov.io/gh/release-engineering/exodus-gw)
 
 - [Source](https://github.com/release-engineering/exodus-gw)
 - [Documentation](https://release-engineering.github.io/exodus-gw/)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,5 +1,4 @@
 alabaster
-coveralls
 mock
 mypy
 pylint

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -165,9 +165,7 @@ alembic==1.18.4 \
 annotated-doc==0.0.4 \
     --hash=sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320 \
     --hash=sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4
-    # via
-    #   fastapi
-    #   typer
+    # via fastapi
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
@@ -589,13 +587,7 @@ coverage[toml]==7.14.1 \
     --hash=sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c \
     --hash=sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253 \
     --hash=sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c
-    # via
-    #   coveralls
-    #   pytest-cov
-coveralls==4.1.0 \
-    --hash=sha256:bfacfda2d443c24fc90d67035027cec15015fff2dbd036427e8bf8f4953dda2e \
-    --hash=sha256:dab364025ba80cbb95ce56c6fc62cd9172d7fd637060ea235dde99d9b46a4494
-    # via -r test-requirements.in
+    # via pytest-cov
 cryptography==49.0.0 \
     --hash=sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001 \
     --hash=sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122 \
@@ -1826,7 +1818,6 @@ requests==2.34.2 \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
     --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
     # via
-    #   coveralls
     #   edgegrid-python
     #   fastpurge
     #   requests-toolbelt
@@ -1838,9 +1829,7 @@ requests-toolbelt==1.0.0 \
 rich==15.0.0 \
     --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
     --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
-    # via
-    #   bandit
-    #   typer
+    # via bandit
 roman-numerals==4.1.0 \
     --hash=sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2 \
     --hash=sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7
@@ -1983,10 +1972,6 @@ s3transfer==0.10.4 \
     --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
     --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
     # via boto3
-shellingham==1.5.4 \
-    --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
-    --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
-    # via typer
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -2103,10 +2088,6 @@ tomlkit==0.15.0 \
     --hash=sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738 \
     --hash=sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3
     # via pylint
-typer==0.26.7 \
-    --hash=sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58 \
-    --hash=sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a
-    # via coveralls
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,9 @@ commands=
 	pytest --cov-report=html --cov=exodus_gw {posargs}
 
 [testenv:cov-ci]
-passenv=GITHUB_*
 usedevelop=true
 commands=
-	pytest --cov=exodus_gw {posargs}
-	coveralls --service=github
+	pytest --cov=exodus_gw --cov-report=xml {posargs}
 
 [testenv:bandit]
 usedevelop=true


### PR DESCRIPTION
Removes coveralls
Update cov-ci testenv to generate coverage.xml report
Adds the codecov action to the CI workflow